### PR TITLE
Agrego opción para compilar para GNU/Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,12 @@ _compilar_electron_win32:
 	cd binarios/pilasBloques-win32-ia32/; makensis instalador.nsi
 	@mv binarios/pilasBloques-win32-ia32/pilas-bloques.exe binarios/pilas-bloques-${VERSION}.exe
 
+_compilar_electron_linux64:
+	@echo "${G}Iniciando compilación a electron a Linux...${N}"
+	rm -rf binarios/pilasBloques-linux-x64/
+	node_modules/.bin/electron-packager dist "pilasBloques" --app-version=${VERSION} --platform=linux --arch=x64 --version=0.37.6 --ignore=node_modules --ignore=bower_components --out=binarios --overwrite --icon=extras/icono.icns
+	node_modules/.bin/electron-installer-flatpak --config=config/linux64-flatpak.json
+	mv binarios/io.atom.electron.pilasBloques_master_x64.flatpak binarios/io.atom.electron.pilasBloques_${VERSION}_x64.flatpak
 
 test_travis:
 	time ember exam --split=10 --parallel

--- a/config/linux64-flatpak.json
+++ b/config/linux64-flatpak.json
@@ -1,0 +1,9 @@
+{
+  "src": "binarios/pilasBloques-linux-x64/",
+  "arch": "x64",
+  "dest": "binarios/",
+  "icon": "extras/icono.icns",
+  "categories": [
+    "Education"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "broccoli-asset-rev": "^2.4.2",
     "broccoli-funnel": "^1.0.6",
     "devtron": "1.3.0",
+    "electron-installer-flatpak": "0.6.0",
     "electron-packager": "7.5.1",
     "electron-prebuilt": "1.3.3",
     "electron-rebuild": "1.2.0",


### PR DESCRIPTION
Usando Flatpak (http://flatpak.org/) que es una manera de distribuir
aplicaciones para todas las distribuciones de Linux modernas. Para
generarlo hacer:

    $ make iniciar
    $ make compilar
    $ make _preparar_electron
    $ make _compilar_electron_linux64

Una vez hecho esto, el paquete flatpak va a estar dentro de la carpeta
binarios. Para probarlo se puede instalar por línea de comandos:

    $ flatpak install --bundle binarios/io.atom.electron.pilasBloques_1.1.2_x64.flatpak
    $ flatpak run io.atom.electron.pilasBloques