### PR TITLE
Ember surge hangs travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,6 @@ after_success:
   - ember build --environment=development
   - test $TRAVIS_BRANCH = "develop" && surge ./dist/ develop-pilas-bloques.surge.sh
   - test $TRAVIS_BRANCH = "master"  && surge ./dist/ master-pilas-bloques.surge.sh
-  - test $TRAVIS_BRANCH = "ember-surge-hangs-travis" && surge ./dist/ develop-pilas-bloques.surge.sh
 deploy:
   skip_cleanup: true
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_install:
 - npm install -g grunt-cli
 - npm install -g node-gyp
 - npm install -g ember-cli
+- npm install -g surge
 before_deploy:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install curl                                  ; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd $TRAVIS_BUILD_DIR && travis/download-homebrew   ; fi
@@ -49,8 +50,10 @@ before_deploy:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make empaquetar                                    ; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo "Evitando hacer binarios en linux...."      ; fi
 after_success:
-  - test $TRAVIS_BRANCH = "develop" && ember surge --environment development --new-domain develop-pilas-bloques.surge.sh
-  - test $TRAVIS_BRANCH = "master"  && ember surge --environment development --new-domain master-pilas-bloques.surge.sh
+  - ember build --environment=development
+  - test $TRAVIS_BRANCH = "develop" && surge ./dist/ develop-pilas-bloques.surge.sh
+  - test $TRAVIS_BRANCH = "master"  && surge ./dist/ master-pilas-bloques.surge.sh
+  - test $TRAVIS_BRANCH = "ember-surge-hangs-travis" && surge ./dist/ develop-pilas-bloques.surge.sh
 deploy:
   skip_cleanup: true
   provider: releases

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "ember-cli-release": "0.2.8",
     "ember-cli-sass": "5.3.1",
     "ember-cli-sri": "^2.1.0",
-    "ember-cli-surge": "1.3.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-cli-yuidoc": "0.8.7",
     "ember-composable-helpers": "0.26.2",


### PR DESCRIPTION
Corrige el problema que evita que las build de TravisCI finalicen a la hora de realizar el deploy de pilas-bloques a surge.