### PR TITLE
Guardar y cargar archivos spbq

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,7 +2,7 @@
   "predef": [
     "document",
     "window",
-    "-Promise",
+    "Promise",
     "Bootstrap",
     "require",
     "$",

--- a/app/components/pilas-blockly.js
+++ b/app/components/pilas-blockly.js
@@ -473,11 +473,6 @@ export default Ember.Component.extend({
       let data = null;
       let solucion = null;
 
-      if (!regex_file.test(archivo.name)) {
-        alert("Lo siento, solo se permiten cargar archivos .spbq");
-        return;
-      }
-
       try {
         data = JSON.parse(contenido);
         solucion = atob(data.solucion);
@@ -487,11 +482,13 @@ export default Ember.Component.extend({
         return;
       }
 
-      if (!regex_version.test(data.version)) {
-        alert("Lo siento, la especificación de versión es incorrecta.");
-        return;
+      if (!regex_file.test(archivo.name)) {
+        alert("Cuidado, este archivo NO tiene extensión .spbq.");
       }
 
+      if (!regex_version.test(data.version)) {
+        alert("Cuidado, la especificación de versión es incorrecta.");
+      }
 
       if (parseInt(data.version) > VERSION_DEL_FORMATO_DE_ARCHIVO) {
         alert("Cuidado, el archivo corresponde a otra versión de la aplicación. Se cargará de todas formas, pero puede fallar.");

--- a/app/components/pilas-blockly.js
+++ b/app/components/pilas-blockly.js
@@ -468,8 +468,8 @@ export default Ember.Component.extend({
 
     //TODO: Mover la creación y cargado del archivo a otro objeto y testear
     cargarSolucion(archivo, contenido) {
-      let regex_file = /\.spbq$/;
-      let regex_version = /^\d+$/;
+      // let regex_file = /\.spbq$/;
+      // let regex_version = /^\d+$/;
       let data = null;
       let solucion = null;
 
@@ -478,20 +478,8 @@ export default Ember.Component.extend({
         solucion = atob(data.solucion);
       } catch (e) {
         console.error(e);
-        alert("Lo siento, el archivo está dañando.");
+        alert("Lo siento, este archivo no tiene una solución de Pilas Bloques.");
         return;
-      }
-
-      if (!regex_file.test(archivo.name)) {
-        alert("Cuidado, este archivo NO tiene extensión .spbq.");
-      }
-
-      if (!regex_version.test(data.version)) {
-        alert("Cuidado, la especificación de versión es incorrecta.");
-      }
-
-      if (parseInt(data.version) > VERSION_DEL_FORMATO_DE_ARCHIVO) {
-        alert("Cuidado, el archivo corresponde a otra versión de la aplicación. Se cargará de todas formas, pero puede fallar.");
       }
 
       if (this.get("modelActividad.nombre") !== data.actividad) {

--- a/app/components/pilas-blockly.js
+++ b/app/components/pilas-blockly.js
@@ -1,6 +1,5 @@
 /* jshint ignore:start */
 import Ember from 'ember';
-let VERSION_DEL_FORMATO_DE_ARCHIVO = 1;
 
 export default Ember.Component.extend({
   classNames: 'desafio-panel-derecho',
@@ -335,14 +334,6 @@ export default Ember.Component.extend({
     }
   },
   
-  descargar(text, name, type) {
-    var a = document.getElementById("placeholder");
-    var file = new Blob([text], {type: type});
-    a.href = URL.createObjectURL(file);
-    a.download = name;
-    a.click();
-  },
-
   setModoTurbo() {
     if (this.modoTuboHabilitado) {
       this.get('pilas').habilitarModoTurbo();
@@ -464,44 +455,6 @@ export default Ember.Component.extend({
         alert(err);
         this.set('envioEnCurso', false);
       });
-    },
-
-    //TODO: Mover la creación y cargado del archivo a otro objeto y testear
-    cargarSolucion(archivo, contenido) {
-      // let regex_file = /\.spbq$/;
-      // let regex_version = /^\d+$/;
-      let data = null;
-      let solucion = null;
-
-      try {
-        data = JSON.parse(contenido);
-        solucion = atob(data.solucion);
-      } catch (e) {
-        console.error(e);
-        alert("Lo siento, este archivo no tiene una solución de Pilas Bloques.");
-        return;
-      }
-
-      if (this.get("modelActividad.nombre") !== data.actividad) {
-        alert(`Cuidado, el archivo indica que es para otra actividad (${data.actividad}). Se cargará de todas formas, pero puede fallar.`);
-      }
-
-      this.set('initial_workspace', solucion);
-    },
-
-    guardarSolucion() {
-      let nombre_de_la_actividad = this.get("modelActividad.nombre");
-      let nombre_surgerido = `${nombre_de_la_actividad}.spbq`;
-
-      let contenido = {
-        version: VERSION_DEL_FORMATO_DE_ARCHIVO,
-        actividad: nombre_de_la_actividad,
-        solucion: btoa(this.get('codigoActualEnFormatoXML'))
-      };
-
-      let contenido_como_string = JSON.stringify(contenido);
-
-      this.descargar(contenido_como_string, nombre_surgerido, 'application/octet-stream');
     },
 
     step() {

--- a/app/components/pilas-boton-cargar.js
+++ b/app/components/pilas-boton-cargar.js
@@ -1,8 +1,12 @@
 import Ember from 'ember';
+let VERSION_DEL_FORMATO_DE_ARCHIVO = 1;
 
 export default Ember.Component.extend({
   tagName: 'span',
   cuandoSelecciona: null,
+  actividad: null,
+  workspace: null,
+  xml: null,
 
   didInsertElement() {
     this.$('#cargarActividadInput').change((event) => {
@@ -14,7 +18,7 @@ export default Ember.Component.extend({
         reader.onload = (e) => {
       	  let contenido = e.target.result;
           
-          this.sendAction('cuandoSelecciona', archivo, contenido);
+          this.cargarSolucion(archivo, contenido);
         };
 
         reader.readAsText(archivo);
@@ -30,9 +34,54 @@ export default Ember.Component.extend({
     document.getElementById('cargarActividadInput').value = null;
   },
 
+  descargar(text, name, type) {
+    var a = document.getElementById("placeholder");
+    var file = new Blob([text], {type: type});
+    a.href = URL.createObjectURL(file);
+    a.download = name;
+    a.click();
+  },
+
+  cargarSolucion(archivo, contenido) {
+    // let regex_file = /\.spbq$/;
+    // let regex_version = /^\d+$/;
+    let data = null;
+    let solucion = null;
+
+    try {
+      data = JSON.parse(contenido);
+      solucion = atob(data.solucion);
+    } catch (e) {
+      console.error(e);
+      alert("Lo siento, este archivo no tiene una solución de Pilas Bloques.");
+      return;
+    }
+
+    if (this.get("actividad.nombre") !== data.actividad) {
+      alert(`Cuidado, el archivo indica que es para otra actividad (${data.actividad}). Se cargará de todas formas, pero puede fallar.`);
+    }
+
+    this.set('workspace', solucion);
+  },
+
   actions: {
     alPulsar() {
       this.$("#cargarActividadInput").click();
-    }
+    },
+
+    guardarSolucion() {
+      let nombre_de_la_actividad = this.get("actividad.nombre");
+      let nombre_surgerido = `${nombre_de_la_actividad}.spbq`;
+
+      let contenido = {
+        version: VERSION_DEL_FORMATO_DE_ARCHIVO,
+        actividad: nombre_de_la_actividad,
+        solucion: btoa(this.get('xml'))
+      };
+
+      let contenido_como_string = JSON.stringify(contenido);
+
+      this.descargar(contenido_como_string, nombre_surgerido, 'application/octet-stream');
+    },
   }
 });

--- a/app/components/pilas-solution-file.js
+++ b/app/components/pilas-solution-file.js
@@ -31,7 +31,7 @@ export default Ember.Component.extend({
   },
 
   limpiarInput() {
-    document.getElementById('cargarActividadInput').value = null;
+    this.$('#cargarActividadInput').value = null;
   },
 
   descargar(text, name, type) {
@@ -65,23 +65,21 @@ export default Ember.Component.extend({
   },
 
   actions: {
-    alPulsar() {
+    abrirSolucion() {
       this.$("#cargarActividadInput").click();
     },
 
     guardarSolucion() {
-      let nombre_de_la_actividad = this.get("actividad.nombre");
-      let nombre_surgerido = `${nombre_de_la_actividad}.spbq`;
+      let activityName = this.get("actividad.nombre");
+      let fileName = `${activityName}.spbq`;
 
       let contenido = {
         version: VERSION_DEL_FORMATO_DE_ARCHIVO,
-        actividad: nombre_de_la_actividad,
+        actividad: activityName,
         solucion: btoa(this.get('xml'))
       };
 
-      let contenido_como_string = JSON.stringify(contenido);
-
-      this.descargar(contenido_como_string, nombre_surgerido, 'application/octet-stream');
+      this.descargar(JSON.stringify(contenido), fileName, 'application/octet-stream');
     },
   }
 });

--- a/app/components/pilas-solution-file.js
+++ b/app/components/pilas-solution-file.js
@@ -55,7 +55,6 @@ export default Ember.Component.extend({
         { name: 'Todos los archivos', extensions: ['*'] }
       ]
     })
-    console.log(archivos)
     if (archivos) 
       this.leerSolucionFS(archivos[0]).catch(alert)
   },

--- a/app/components/pilas-solution-file.js
+++ b/app/components/pilas-solution-file.js
@@ -8,15 +8,14 @@ export default Ember.Component.extend({
   workspace: null,
   xml: null,
 
-  leer(archivo) {
+  leerSolucion(archivo) {
     var reader = new FileReader()
-
-    reader.onload = (e) => {
-      let contenido = e.target.result
-      this.cargarSolucion(contenido)
-    }
-
-    reader.readAsText(archivo)
+    return new Promise((resolve, reject) => {
+      reader.onerror = (err) => reject(err)
+      reader.onload = (event) => resolve(event.target.result)
+      reader.readAsText(archivo)
+    })
+    .then((contenido) => this.cargarSolucion(contenido))
   },
 
   descargar(text, name, type) {
@@ -53,13 +52,8 @@ export default Ember.Component.extend({
     this.fileInput().change((event) => {
       let archivo = event.target.files[0]
 
-      if (archivo) {
-        try {
-          this.leer(archivo)
-        } catch (error) {
-          alert(error) //TODO: Fix!! Las excepciones no llegan hasta acá, habría que trabajar mejor el async
-        }
-      }
+      if (archivo)
+        this.leerSolucion(archivo).catch(alert)
 
       this.limpiarInput() // Fuerza a que se pueda cargar dos o más veces el mismo archivo
       return false

--- a/app/components/pilas-solution-file.js
+++ b/app/components/pilas-solution-file.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
-let VERSION_DEL_FORMATO_DE_ARCHIVO = 1;
+import Ember from 'ember'
+let VERSION_DEL_FORMATO_DE_ARCHIVO = 1
 
 export default Ember.Component.extend({
   tagName: 'span',
@@ -8,83 +8,88 @@ export default Ember.Component.extend({
   workspace: null,
   xml: null,
 
-  didInsertElement() {
-    this.fileInput().change((event) => {
-      let archivo = event.target.files[0];
+  leer(archivo) {
+    var reader = new FileReader()
 
-      if (archivo) {
-        var reader = new FileReader();
+    reader.onload = (e) => {
+      let contenido = e.target.result
+      this.cargarSolucion(contenido)
+    }
 
-        reader.onload = (e) => {
-      	  let contenido = e.target.result;
-          
-          this.cargarSolucion(contenido);
-        };
-
-        reader.readAsText(archivo);
-      }
-
-      // Fuerza a que se pueda cargar dos o más veces el mismo archivo.
-      this.limpiarInput();
-      return false;
-    });
-  },
-
-  limpiarInput() {
-    this.fileInput().value = null;
+    reader.readAsText(archivo)
   },
 
   descargar(text, name, type) {
-    var a = document.getElementById("placeholder");
-    var file = new Blob([text], {type: type});
-    a.href = URL.createObjectURL(file);
-    a.download = name;
+    var a = document.getElementById("placeholder")
+    var file = new Blob([text], {type: type})
+    a.href = URL.createObjectURL(file)
+    a.download = name
     a.type = type
     a.click()
   },
 
   cargarSolucion(contenido) {
-    // let regex_file = /\.spbq$/;
-    // let regex_version = /^\d+$/;
-    let data = null;
-    let solucion = null;
+    // let regex_file = /\.spbq$/
+    // let regex_version = /^\d+$/
+    let data = null
+    let solucion = null
 
     try {
-      data = JSON.parse(contenido);
-      solucion = atob(data.solucion);
+      data = JSON.parse(contenido)
+      solucion = atob(data.solucion)
     } catch (e) {
-      console.error(e);
-      alert("Lo siento, este archivo no tiene una solución de Pilas Bloques.");
-      return;
+      console.error(e)
+      throw "Lo siento, este archivo no tiene una solución de Pilas Bloques."
     }
+
+    this.set('workspace', solucion)
 
     if (this.get("actividad.nombre") !== data.actividad) {
-      alert(`Cuidado, el archivo indica que es para otra actividad (${data.actividad}). Se cargará de todas formas, pero puede fallar.`);
+      throw `Cuidado, el archivo indica que es para otra actividad (${data.actividad}). Se cargará de todas formas, pero puede fallar.`
     }
+  },
 
-    this.set('workspace', solucion);
+  didInsertElement() {
+    this.fileInput().change((event) => {
+      let archivo = event.target.files[0]
+
+      if (archivo) {
+        try {
+          this.leer(archivo)
+        } catch (error) {
+          alert(error) //TODO: Fix!! Las excepciones no llegan hasta acá, habría que trabajar mejor el async
+        }
+      }
+
+      this.limpiarInput() // Fuerza a que se pueda cargar dos o más veces el mismo archivo
+      return false
+    })
   },
 
   fileInput() {
     return this.$("#cargarActividadInput")
   },
 
+  limpiarInput() {
+    this.fileInput().value = null
+  },
+
   actions: {
     abrirSolucion() {
-      this.fileInput().click();
+      this.fileInput().click()
     },
 
     guardarSolucion() {
-      let activityName = this.get("actividad.nombre");
-      let fileName = `${activityName}.spbq`;
+      let activityName = this.get("actividad.nombre")
+      let fileName = `${activityName}.spbq`
 
       let contenido = {
         version: VERSION_DEL_FORMATO_DE_ARCHIVO,
         actividad: activityName,
         solucion: btoa(this.get('xml'))
-      };
+      }
 
-      this.descargar(JSON.stringify(contenido), fileName, 'application/octet-stream');
+      this.descargar(JSON.stringify(contenido), fileName, 'application/octet-stream')
     },
   }
-});
+})

--- a/app/components/pilas-solution-file.js
+++ b/app/components/pilas-solution-file.js
@@ -9,7 +9,7 @@ export default Ember.Component.extend({
   xml: null,
 
   didInsertElement() {
-    this.$('#cargarActividadInput').change((event) => {
+    this.fileInput().change((event) => {
       let archivo = event.target.files[0];
 
       if (archivo) {
@@ -18,7 +18,7 @@ export default Ember.Component.extend({
         reader.onload = (e) => {
       	  let contenido = e.target.result;
           
-          this.cargarSolucion(archivo, contenido);
+          this.cargarSolucion(contenido);
         };
 
         reader.readAsText(archivo);
@@ -31,7 +31,7 @@ export default Ember.Component.extend({
   },
 
   limpiarInput() {
-    this.$('#cargarActividadInput').value = null;
+    this.fileInput().value = null;
   },
 
   descargar(text, name, type) {
@@ -39,10 +39,11 @@ export default Ember.Component.extend({
     var file = new Blob([text], {type: type});
     a.href = URL.createObjectURL(file);
     a.download = name;
-    a.click();
+    a.type = type
+    a.click()
   },
 
-  cargarSolucion(archivo, contenido) {
+  cargarSolucion(contenido) {
     // let regex_file = /\.spbq$/;
     // let regex_version = /^\d+$/;
     let data = null;
@@ -64,9 +65,13 @@ export default Ember.Component.extend({
     this.set('workspace', solucion);
   },
 
+  fileInput() {
+    return this.$("#cargarActividadInput")
+  },
+
   actions: {
     abrirSolucion() {
-      this.$("#cargarActividadInput").click();
+      this.fileInput().click();
     },
 
     guardarSolucion() {

--- a/app/templates/components/pilas-blockly.hbs
+++ b/app/templates/components/pilas-blockly.hbs
@@ -29,9 +29,7 @@
 
       {{#unless estoyEnMoodle}}
 
-        {{pilas-boton-cargar cuandoSelecciona="cargarSolucion"}}
-
-        <button class='btn btn-default' {{action "guardarSolucion"}}><i class="fa fa-download"></i> Guardar</button>
+        {{pilas-boton-cargar actividad=modelActividad workspace=initial_workspace xml=codigoActualEnFormatoXML}}
 
         {{pilas-toggle isDisabled=this.ejecutando isChecked=this.modoTuboHabilitado icon="fa fa-bolt" tooltip="Modo Turbo" element-id="modo-turbo"}}
 

--- a/app/templates/components/pilas-blockly.hbs
+++ b/app/templates/components/pilas-blockly.hbs
@@ -29,7 +29,7 @@
 
       {{#unless estoyEnMoodle}}
 
-        {{pilas-boton-cargar actividad=modelActividad workspace=initial_workspace xml=codigoActualEnFormatoXML}}
+        {{pilas-solution-file actividad=modelActividad workspace=initial_workspace xml=codigoActualEnFormatoXML}}
 
         {{pilas-toggle isDisabled=this.ejecutando isChecked=this.modoTuboHabilitado icon="fa fa-bolt" tooltip="Modo Turbo" element-id="modo-turbo"}}
 

--- a/app/templates/components/pilas-boton-cargar.hbs
+++ b/app/templates/components/pilas-boton-cargar.hbs
@@ -4,3 +4,5 @@
 <a id="placeholder" class="hidden">..</a>
 
 <button class='btn btn-default' {{action "alPulsar"}}><i class="fa fa-folder-open-o"></i> Abrir</button>
+
+<button class='btn btn-default' {{action "guardarSolucion"}}><i class="fa fa-download"></i> Guardar</button>

--- a/app/templates/components/pilas-solution-file.hbs
+++ b/app/templates/components/pilas-solution-file.hbs
@@ -3,6 +3,6 @@
 <input type='file' id="cargarActividadInput" accept=".spbq" class="hidden"/>
 <a id="placeholder" class="hidden">..</a>
 
-<button class='btn btn-default' {{action "alPulsar"}}><i class="fa fa-folder-open-o"></i> Abrir</button>
+<button class='btn btn-default' {{action "abrirSolucion"}}><i class="fa fa-folder-open-o"></i> Abrir</button>
 
 <button class='btn btn-default' {{action "guardarSolucion"}}><i class="fa fa-download"></i> Guardar</button>

--- a/extras/electron.js
+++ b/extras/electron.js
@@ -1,17 +1,17 @@
 /* jshint node: true */
 
-var electron = require('electron');
+var electron = require('electron')
 
-var app = electron.app;
-var mainWindow = null;
-var BrowserWindow = electron.BrowserWindow;
+var app = electron.app
+var mainWindow = null
+var BrowserWindow = electron.BrowserWindow
 
 
-var fs = require('fs');
+var fs = require('fs')
 
 app.on('window-all-closed', function onWindowAllClosed() {
-  app.quit();
-});
+  app.quit()
+})
 
 app.on('ready', function onReady() {
 
@@ -20,17 +20,34 @@ app.on('ready', function onReady() {
     height: 672,
     minWidth: 500,
     minHeight: 500,
-  });
+  })
 
-  //mainWindow.openDevTools();
+  // mainWindow.openDevTools()
 
-  delete mainWindow.module;
+  delete mainWindow.module
 
-  mainWindow.loadURL('file://' + __dirname + '/index.html');
-  mainWindow.setMenu(null);
+  mainWindow.loadURL('file://' + __dirname + '/index.html')
+  mainWindow.setMenu(null)
 
   mainWindow.on('closed', function onClosed() {
-    mainWindow = null;
-  });
+    mainWindow = null
+  })
 
-});
+  const { dialog } = require('electron')
+  mainWindow.webContents.session.on('will-download', (event, downloadItem, webContents) => {
+    event.preventDefault()
+    var fileName = dialog.showSaveDialog({
+      defaultPath: downloadItem.getFilename(),
+      filters: [
+        { name: 'Solución de Pilas Bloques', extensions: ['spbq'] },
+        { name: 'Todos los archivos', extensions: ['*'] }
+      ]
+    })
+
+    if (fileName) {
+      downloadItem.setSavePath(fileName)
+    } else {
+      downloadItem.cancel()
+    }
+  })
+})

--- a/extras/electron.js
+++ b/extras/electron.js
@@ -35,7 +35,7 @@ app.on('ready', function onReady() {
 
   const { dialog } = require('electron')
   mainWindow.webContents.session.on('will-download', (event, downloadItem, webContents) => {
-    event.preventDefault()
+    
     var fileName = dialog.showSaveDialog({
       defaultPath: downloadItem.getFilename(),
       filters: [

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -7,7 +7,7 @@
     "location",
     "setTimeout",
     "$",
-    "-Promise",
+    "Promise",
     "define",
     "console",
     "visit",
@@ -27,7 +27,8 @@
     "currentRouteName",
     "Prism",
     "ga",
-    "Blockly"
+    "Blockly",
+    "Blob"
   ],
   "asi": true,
   "node": false,

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 
-const { RSVP: { Promise } } = Ember;
+const { RSVP: { Promise } } = Ember; // jshint ignore:line
 
 export default function(name, options = {}) {
   module(name, {

--- a/tests/unit/components/pilas-blockly-test.js
+++ b/tests/unit/components/pilas-blockly-test.js
@@ -11,7 +11,6 @@ moduleFor('component:pilas-blockly', 'Unit | Components | pilas-blockly', {
 
     let ctrl = this.subject();
     ctrl.pilas = pilasMock; //TODO: Injectar como service
-    ctrl.descargar = sinon.spy();
     ctrl.set('modelActividad', actividadMock);
     sinon.resetHistory();
   }
@@ -78,14 +77,3 @@ test('Al reiniciar settea flags y reinicia la escena de pilas', function(assert)
   assert.ok(pilasMock.reiniciarEscenaCompleta.called);
 });
 
-
-test('Al guardar solución hace una descarga con la solución', function(assert) {
-  let ctrl = this.subject();
-  ctrl.send('guardarSolucion');
-
-  assert.ok(ctrl.descargar.calledWith(
-    JSON.stringify({version:1, actividad:"Actividad_Mock", solucion:""}),
-    'Actividad_Mock.spbq',
-    'application/octet-stream'
-  ));
-});

--- a/tests/unit/components/pilas-solution-file-test.js
+++ b/tests/unit/components/pilas-solution-file-test.js
@@ -101,7 +101,7 @@ function fileTest(mensaje, contenido, cbGood, cbFail) {
     let archivo = new Blob([JSON.stringify(contenido)])
     
     ctrl
-    .leerSolucion(archivo)
+    .leerSolucionWeb(archivo)
     .then(() => {
       cbGood(assert)
       done()

--- a/tests/unit/components/pilas-solution-file-test.js
+++ b/tests/unit/components/pilas-solution-file-test.js
@@ -1,0 +1,126 @@
+import { moduleFor, test } from 'ember-qunit'
+import { actividadMock } from '../../helpers/mocks'
+import sinon from 'sinon'
+
+let ctrl
+let actividad = actividadMock.nombre
+let solucion = "PHhtbCB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94aHRtbCI+PHZhcmlhYmxlcz48L3ZhcmlhYmxlcz48YmxvY2sgdHlwZT0iYWxfZW1wZXphcl9hX2VqZWN1dGFyIiBpZD0idX4vczBQV1BEWkQ1aFEtLFFnPXQiIGRlbGV0YWJsZT0iZmFsc2UiIG1vdmFibGU9ImZhbHNlIiBlZGl0YWJsZT0iZmFsc2UiIHg9IjIyNyIgeT0iMTUiPjwvYmxvY2s+PC94bWw+"
+
+moduleFor('component:pilas-solution-file', 'Unit | Components | pilas-solution-file', {
+  setup() {
+    ctrl = this.subject()
+    ctrl.set('actividad', actividadMock)
+    sinon.resetHistory()
+  }
+})
+
+
+let solucionCompleta = {
+  version: 1,
+  actividad,
+  solucion
+}
+
+goodFileTest("Carga un archivo de solución correctamente", solucionCompleta)
+
+let solucionCompletaConVersionPosterior = {
+  version: 999,
+  actividad,
+  solucion
+}
+
+goodFileTest("Carga un archivo de solución aunque tenga una versión posterior", solucionCompletaConVersionPosterior)
+
+let solucionCompletaSinVersion = {
+  actividad,
+  solucion
+}
+
+goodFileTest("Carga un archivo de solución aunque no tenga versión", solucionCompletaSinVersion)
+
+
+function goodFileTest(mensaje, contenido) {
+  test(mensaje, function(assert) {
+    let done = assert.async()
+    let archivo = new Blob([JSON.stringify(contenido)])
+    
+    ctrl
+    .leerSolucion(archivo)
+    .then(() => {
+      assert.ok(ctrl.get("workspace"))
+      done()
+    })
+    .catch(() => done())
+  })  
+}
+
+
+
+let solucionParaOtraActividad = {
+  version: 1,
+  actividad: "Otra_Actividad",
+  solucion
+}
+
+test("Verifica que sea para la actividad que se está cargando", function(assert) {
+  let done = assert.async()
+  let contenido = solucionParaOtraActividad
+  let archivo = new Blob([JSON.stringify(contenido)])
+  
+  ctrl
+  .leerSolucion(archivo)
+  .then(() => done())
+  .catch((err) => {
+    assert.equal(err, "Cuidado, el archivo indica que es para otra actividad (Otra_Actividad). Se cargará de todas formas, pero puede fallar.")
+    done()
+  })
+})
+
+test("Aunque no sea una solución para la actividad, debería cargarla al workspace", function(assert) {
+  let done = assert.async()
+  let contenido = solucionParaOtraActividad
+  let archivo = new Blob([JSON.stringify(contenido)])
+  
+  ctrl
+  .leerSolucion(archivo)
+  .then(() => done())
+  .catch(() => {
+    assert.ok(ctrl.get("workspace"))
+    done()
+  })
+})
+
+
+
+let archivoSinSolucion = {
+  version: 1,
+  actividad,
+}
+
+test("Verifica que tenga una solucion", function(assert) {
+  let done = assert.async()
+  let contenido = archivoSinSolucion
+  let archivo = new Blob([JSON.stringify(contenido)])
+  
+  ctrl
+  .leerSolucion(archivo)
+  .then(() => done())
+  .catch((err) => {
+    assert.equal(err, "Lo siento, este archivo no tiene una solución de Pilas Bloques.")
+    done()
+  })
+})
+
+test("No carga ninguna solución si el archivo no tiene una", function(assert) {
+  let done = assert.async()
+  let contenido = archivoSinSolucion
+  let archivo = new Blob([JSON.stringify(contenido)])
+  
+  ctrl
+  .leerSolucion(archivo)
+  .then(() => done())
+  .catch(() => {
+    assert.notOk(ctrl.get("workspace"))
+    done()
+  })
+})

--- a/tests/unit/components/pilas-solution-file-test.js
+++ b/tests/unit/components/pilas-solution-file-test.js
@@ -11,9 +11,24 @@ moduleFor('component:pilas-solution-file', 'Unit | Components | pilas-solution-f
   setup() {
     ctrl = this.subject()
     ctrl.set('actividad', actividadMock)
+    ctrl.descargar = sinon.stub()
     sinon.resetHistory()
   }
 })
+
+test("Al guardar solución crea el archivo correctamente", function(assert) {
+  let contenido = JSON.stringify({
+    version,
+    actividad,
+    solucion: "bnVsbA=="
+  })
+  let archivo = `${actividad}.spbq`
+  let tipo = 'application/octet-stream'
+  
+  ctrl.send("guardarSolucion")
+  assert.ok(ctrl.descargar.calledWith(contenido, archivo, tipo))
+})
+
 
 
 let solucionCompleta = {


### PR DESCRIPTION
Fix https://github.com/Program-AR/pilas-bloques/issues/298

- Al abrir un archivo, hay un `if` del demonio que se fija si hay que usar cosas de Electron o Web.
- Al descargar, Electron se mete en el medio del evento y abre su propio dialog.

Estos dialog tienen configurado el filtro de .spbq para "Solución de Pilas Bloques" ;)

Solo se testea la parte web del componente, los otros tests quedarán para el futuro (cuando corramos tests en el server y no en el cliente).

Les dejo algunos screen de un **windows** ;)

- Ahora aparece el tipo de archivo:
![screenshot 1](https://user-images.githubusercontent.com/4098184/57562767-240ced80-736c-11e9-9f61-9a30c85ea04f.jpg)

- Al cambiar el nombre, igual lo guarda con la extensión piola
![screenshot 2](https://user-images.githubusercontent.com/4098184/57562768-25d6b100-736c-11e9-9718-21e27af7dfa9.jpg)

- Al abrir muestra el tipo de archivos que filtra. También tiene la opción de ver todos.
![screenshot 3](https://user-images.githubusercontent.com/4098184/57562769-27a07480-736c-11e9-9636-a2cc5e45518b.jpg)
