### PR TITLE
Rotation alf

### DIFF
--- a/app/breakpoints.js
+++ b/app/breakpoints.js
@@ -1,6 +1,4 @@
 export default {
-  mobile:  '(max-width: 768px)',
-  tablet:  '(min-width: 769px) and (max-width: 849px)',
-  desktop: '(min-width: 850px) and (max-width: 1200px)',
-  jumbo:   '(min-width: 1201px)'
+  portrait: '(orientation: portrait)',
+  mobile:  '(max-width: 849px)'
 };

--- a/app/components/challenge-workspace.js
+++ b/app/components/challenge-workspace.js
@@ -66,15 +66,11 @@ export default Component.extend({
       this.set("shouldUseFloatingMode", !this.get("shouldUseFloatingMode"));
       this.send("updateBlockyWorkspaceBounds");
 
-      if (this.get("shouldUseFloatingMode")) {
+      this.send("showScene");
+      if (this.get("shouldUseFloatingMode")) 
         this.send("makeDraggable");
-        this.send("hideScene");
-      }
-
-      else {
-        this.send("showScene");
+      else 
         this.send("makeNotDraggable");
-      }
 
     },
 
@@ -82,17 +78,19 @@ export default Component.extend({
       let elmnt = document.getElementById("draggable");
       let canvas = document.getElementsByClassName("pilas-canvas")[0];
       let exerciseCard = document.getElementsByClassName("exercise-card")[0];
-      let blocklyFlyout = document.getElementsByClassName("blocklyFlyout")[0];
+      let pilasBlockly = document.getElementsByClassName("pilas-blockly")[0].getBoundingClientRect();
 
       var pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
 
-      canvas.style.height = 240 + "px";
-      canvas.style.width = 210 + "px";
-      exerciseCard.style.height = 240 + "px";
-      exerciseCard.style.width = 210 + "px";
+      const miniature = {height: 240, width: 210}
 
-      elmnt.style.top = (blocklyFlyout.height.baseVal.value - 50) + "px";
-      elmnt.style.left = (blocklyFlyout.width.baseVal.value + 25) + "px";
+      canvas.style.height = miniature.height + "px";
+      canvas.style.width = miniature.width + "px";
+      exerciseCard.style.height = miniature.height + "px";
+      exerciseCard.style.width = miniature.width + "px";
+
+      elmnt.style.top = (pilasBlockly.bottom - miniature.height) + "px";
+      elmnt.style.left = (pilasBlockly.left + 15) + "px";
       elmnt.style.position = "fixed";
 
       elmnt.onmousedown = onMouseDown;

--- a/app/styles/challenge-workspace.scss
+++ b/app/styles/challenge-workspace.scss
@@ -28,13 +28,9 @@
   min-height: calc(100vh - 210px); // calculate the height minus header and footer in px.
 }
 
-.pilas-blockly-container-collapsed {
-  background-color: var(--theme-background-color);
-  position: inherit;
-  border-radius: 10px;
+.floating-mode {
   height: calc(100vh - 70px);
   margin-top: 10px;
-  margin-bottom: 0px;
   margin-right: 5px;
 }
 

--- a/app/styles/challenge-workspace.scss
+++ b/app/styles/challenge-workspace.scss
@@ -21,6 +21,7 @@
   border-radius: 10px;
   position: inherit;
   width: 100%; 
+  min-width: 700px;
   margin-top: 0px;
   margin-bottom: 0px;
   margin-right: 0px;

--- a/app/styles/phone-rotation-warning.scss
+++ b/app/styles/phone-rotation-warning.scss
@@ -8,50 +8,24 @@
     height: 100vh;
     width: 100vw;
     z-index: 999;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    align-items: center;
 }
 
-.phone-rotation-img {
-    height: 60%;
-    width:100%;
-    transform: translateY(30%);
+.phone-rotation img {
+    width: 60%;
 }
 
-.phone-rotation-title {
-    position: absolute;
+.phone-rotation span {
+    padding: 2rem;
     color: whitesmoke;
-    font-size: 3.5rem;
-    top: 8%;
-    left: 10%;
-    text-shadow: 1px 1px 5px black;
-    font-weight: bold;
-}
-
-.phone-rotation-text {
-    position: absolute;
-    color: whitesmoke;
-    top: 83%;
-    left: 10%;
     text-shadow: 1px 1px 5px black;
     font-size: 3.5rem;
     font-weight: bold;
 }
 
-.phone-rotation-title-uppercase {
-    position: absolute;
-    color: whitesmoke;
+.phone-rotation .uppercase {
     font-size: 2.5rem;
-    top: 8%;
-    left: 10%;
-    text-shadow: 1px 1px 5px black;
-    font-weight: bold;
-}
-
-.phone-rotation-text-uppercase {
-    position: absolute;
-    color: whitesmoke;
-    top: 85%;
-    left: 10%;
-    text-shadow: 1px 1px 5px black;
-    font-size: 2.5rem;
-    font-weight: bold;
 }

--- a/app/styles/ribbons.scss
+++ b/app/styles/ribbons.scss
@@ -1,5 +1,5 @@
 body{
-  overflow-x: hidden;
+  overflow-x: auto;
 }
 
 .ribbon{

--- a/app/styles/scene.scss
+++ b/app/styles/scene.scss
@@ -29,31 +29,10 @@
     overflow: hidden;
 }
 
-@media (max-width: 1366px){
+@media (max-width: 1280px){
     .pilas-canvas {
         width: 300px;   
-        height: 350px;
-    }
-}
-
-@media (max-width: 1280px) {
-    .pilas-canvas {
-        width: 250px;   
-        height: 300px;
-    }
-}
-
-@media (max-width: 1024px) {
-    .pilas-canvas {
-        width: 250px;   
-        height: 300px;
-    }
-}
-
-@media (max-width: 800px) {
-    .pilas-canvas {
-        width: 200px;   
-        height: 250px;
+        height: 343px;
     }
 }
 

--- a/app/templates/components/challenge-workspace.hbs
+++ b/app/templates/components/challenge-workspace.hbs
@@ -14,7 +14,7 @@
   {{/unless}}
 
   <div class="flex layout-row">
-    <PaperCard class={{if shouldUseFloatingMode "flex-grow pilas-blockly-container-collapsed" "flex-grow pilas-blockly-container"}}>
+    <PaperCard class={{if shouldUseFloatingMode "flex-grow pilas-blockly-container floating-mode" "flex-grow pilas-blockly-container"}}>
       <PilasBlockly
         @guardar={{'guardar'}}
         @registrarPrimerCodigo={{'registrarPrimerCodigo'}}

--- a/app/templates/components/challenge-workspace.hbs
+++ b/app/templates/components/challenge-workspace.hbs
@@ -2,7 +2,7 @@
   
 <div class="workspace flex layout-column {{if modoLecturaSimple 'aplicar-modo-lectura-simple'}}">
   
-  {{#if (or (media 'isMobile') (media 'isTablet')) }}
+  {{#if (and (media 'isMobile') (media 'isPortrait')) }}
     <PhoneRotationWarning @modoLecturaSimple={{modoLecturaSimple}} />
   {{/if}}
 

--- a/app/templates/components/footer.hbs
+++ b/app/templates/components/footer.hbs
@@ -3,9 +3,7 @@
     <Spinner/>
   {{else}}
     <div class="layout-row flex-grow">
-      {{#if (or (media 'isDesktop') (media 'isJumbo'))}}
-          <a class="program-ar-logo" href="http://program.ar"/>
-      {{/if}}
+      <a class="program-ar-logo" href="http://program.ar"/>
       <p class="app-version"><code>Versión:<span clas="version-number">{{app-version}}</span></code></p>
       <span class="flex"></span>
       <PaperButton @onClick={{action openReportAProblemModel}} @disabled={{false}} @raised={{false}} @fab={{false}} @bubbles={{true}}>{{paper-icon "info" class="menu-button-icon"}}<span class="menu-button-typography">¿Algún problema con este ejercicio?</span></PaperButton>

--- a/app/templates/components/phone-rotation-warning.hbs
+++ b/app/templates/components/phone-rotation-warning.hbs
@@ -1,5 +1,9 @@
-<PaperCard class="phone-rotation flex layout-column">
-    <span class={{if modoLecturaSimple "phone-rotation-title-uppercase" "phone-rotation-title"}}>Intentá rotar el celular.</span>
-    <img class="phone-rotation-img" src='imagenes/phone-rotation.png' />
-    <span class={{if modoLecturaSimple "phone-rotation-text-uppercase" "phone-rotation-text"}}>Pilas Bloques necesita una pantalla más ancha.</span>
+<PaperCard class="phone-rotation">
+    <span class={{if modoLecturaSimple "uppercase" ""}}>
+        Intentá rotar el celular
+    </span>
+    <img src='imagenes/phone-rotation.png' />
+    <span class={{if modoLecturaSimple "uppercase" ""}}>
+        Pilas Bloques necesita una pantalla más ancha
+    </span>
 </PaperCard>


### PR DESCRIPTION
Mejoras:

![responsivenessPilasBloques](https://user-images.githubusercontent.com/5421992/86440390-b85cb100-bce0-11ea-8edb-03962558db77.gif)

6ee42a7 Refactor phone rotation css. Now is way simpler
Saqué mucho código falopa y repetido que había en el CSS. Lo resolví con flex para que mantuviera la relación de aspecto de Toto y ajustara el texto alrededor.

bfb768c Breakpoints simplified for phonerotationWarning
Miren la magia de Ember Responsive: puedo preguntar si isPortrait, lo cual básicamente se fija si es más alto que ancho :grin: 
https://github.com/Program-AR/pilas-bloques/blob/bfb768cfe63cd851f48d01cc939dc7b6e6b04a0f/app/templates/components/challenge-workspace.hbs#L5-L7

También volé el `jumbo`, el `tablet` y el `desktop`, dejando sólo un `mobile`, que sirve únicamente para saber si mostrar a Toto. Quedó declarativo: "si estoy en mobile y tengo el celu derecho, muestro a Toto".

a0a784b Media queries simplified to one for pilas canvas
Esto es lo que hicimos en la call de que haiga un solo media query, y dos tamaños del canvas por ahora.

4ea5b13 When screen is small, horizontal scroll bar appear
Como se ve en el gif, cuando las pantallas de compu son chicas (800 x 600 y menores aún) no se muestra toto, sino que en su lugar se muestra una barra abajo para poder scrollear a la derecha y poder acceder a los botones y a la escena.

0af64fe Blockly space is now minimum 700px
Esto también lo hicimos en la call. El objetivo es que siempre haya lugar para programar.

029f4e7 Footer Program.AR logo now always shows
Esto también hablamos de hacerlo.

Y por último, tuneé la posición inicial de la miniatura e hice que aparezca apenas apretás el cambio de pantalla completa:
![spawning](https://user-images.githubusercontent.com/5421992/86456542-97a05580-bcf8-11ea-92c4-a3fd2b8c8039.gif)
