### PR TITLE
Modo Turbo al cambiar de desafío - Issue #665

### DIFF
--- a/app/components/turbo-mode-toggle.js
+++ b/app/components/turbo-mode-toggle.js
@@ -1,26 +1,34 @@
 import Component from '@ember/component';
 import Ember from 'ember';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
+    tagName: 'div',
+    classNames: [],
     turboMode: false,
+    storage: service(),
 
+    didRender() {
+        this.set('turboMode', this.storage.getUseTurboMode());
+        if (this.turboMode) {
+            this.pilas.habilitarModoTurbo();
+        }
+    },
+    
     actions: {
         updateTurboMode() {
-
             if (this.turboMode) {
+                this.storage.toggleTurboMode();
                 this.pilas.deshabilitarModoTurbo();
-                this.set("turboMode", false);
             }
-
             else {
+                this.storage.toggleTurboMode()
                 this.pilas.habilitarModoTurbo();
-                this.set("turboMode", true);
             }
 
             if (!Ember.testing) {
                 this.set("needShowTurboModeIndicator", true);
             }
-
         },
     }
 });

--- a/app/services/storage.js
+++ b/app/services/storage.js
@@ -7,6 +7,7 @@ export default Ember.Service.extend({
   ANALYTICS_KEY: 'PB_ANALYTICS_SESSION',
   TOS_ACCEPTED_KEY: 'PB_TOS_ACCEPTED',
   USE_NIGHT_THEME_KEY: 'PB_USE_NIGHT_THEME',
+  USE_TURBO_MODE_KEY: 'PB_USE_TURBO_MODE',
 
   getUserId() {
     const user = this.getUser()
@@ -30,6 +31,10 @@ export default Ember.Service.extend({
   getUseNightTheme() { return this._get(this.USE_NIGHT_THEME_KEY) },
 
   toggleNightTheme() { this._save(this.USE_NIGHT_THEME_KEY, !this.getUseNightTheme()) },
+
+  getUseTurboMode() { return this._get(this.USE_TURBO_MODE_KEY) },
+
+  toggleTurboMode() { this._save(this.USE_TURBO_MODE_KEY, !this.getUseTurboMode()) },
 
   clear() { localStorage.clear() },
 


### PR DESCRIPTION
Básicamente lo que se hizo fue que cuando se cambia de desafío quede fijo el modo turbo porque antes cuando se cambiaba de desafío se debía activar de nuevo el modo.
Para esto lo que se hizo fue guardar de manera global cuando se active el modo turbo o desactive y ahí poder trabajar con ese modo en varios desafíos.
Program-AR#665.