### PR TITLE
doesNotUseRecursion fix

### DIFF
--- a/app/utils/expectations.js
+++ b/app/utils/expectations.js
@@ -24,7 +24,7 @@ export const notTooLong = (limit = 7) => (declaration) =>
   newExpectation(`within ${toEDLString(declaration)} count(calls) <= ${limit - 1}`, 'too_long', { declaration, limit })
 
 export const doesNotUseRecursion = (declaration) =>
-  newExpectation(`through ${toEDLString(declaration)} ! calls ${toEDLString(declaration)}`, 'does_not_use_recursion', { declaration })
+  newExpectation(`not (through ${toEDLString(declaration)} calls ${toEDLString(declaration)})`, 'does_not_use_recursion', { declaration })
 
 // UTILS
 const newExpectation = (expect, id, opts = {}) =>

--- a/app/utils/expectations.js
+++ b/app/utils/expectations.js
@@ -12,7 +12,7 @@ export const multiExpect = (...expectations) => (element) =>
 
 // DECLARATION EXPECTATIONS
 export const doSomething = (declaration) =>
-  newExpectation(`${countWithRecursiveCalling(declaration)} >= 1`, 'do_something', { declaration })
+  newExpectation(`${countCalls(declaration)} >= 1`, 'do_something', { declaration })
 
 export const isUsed = (declaration) =>
   newExpectation(`calls ${toEDLString(declaration)}`, 'is_used', { declaration })
@@ -21,16 +21,18 @@ export const isUsedFromMain = (declaration) =>
   newExpectation(`through ${toEDLString(entryPointType)} calls ${toEDLString(declaration)}`, 'is_used_from_main', { declaration })
 
 export const notTooLong = (limit = 7) => (declaration) =>
-  newExpectation(`${countWithRecursiveCalling(declaration)} <= ${limit - 1}`, 'too_long', { declaration, limit })
+  newExpectation(`${countCalls(declaration)} <= ${limit - 1}`, 'too_long', { declaration, limit })
 
 export const doesNotUseRecursion = (declaration) =>
   newExpectation(`not (through ${toEDLString(declaration)} calls ${toEDLString(declaration)})`, doesNotUseRecursionId, { declaration })
 
 // UTILS
-const newExpectation = (expect, id, opts = {}) =>
+export const newExpectation = (expect, id, opts = {}) =>
   `expectation "${stringify(id, opts)}": ${expect};`
 
-const countWithRecursiveCalling = (declaration) =>
+// Use this to count number of calls inside a procedure, including recursive calls
+// Mulang count does not count recursive calls
+export const countCalls = (declaration) =>
   `within ${toEDLString(declaration)} count(calls) + count(calls ${toEDLString(declaration)})`
 
 export const stringify = (id, opts) =>

--- a/app/utils/expectations.js
+++ b/app/utils/expectations.js
@@ -12,7 +12,7 @@ export const multiExpect = (...expectations) => (element) =>
 
 // DECLARATION EXPECTATIONS
 export const doSomething = (declaration) =>
-  newExpectation(`within ${toEDLString(declaration)} ${countWithRecursiveCalling(declaration)} >= 1`, 'do_something', { declaration })
+  newExpectation(`${countWithRecursiveCalling(declaration)} >= 1`, 'do_something', { declaration })
 
 export const isUsed = (declaration) =>
   newExpectation(`calls ${toEDLString(declaration)}`, 'is_used', { declaration })
@@ -21,7 +21,7 @@ export const isUsedFromMain = (declaration) =>
   newExpectation(`through ${toEDLString(entryPointType)} calls ${toEDLString(declaration)}`, 'is_used_from_main', { declaration })
 
 export const notTooLong = (limit = 7) => (declaration) =>
-  newExpectation(`within ${toEDLString(declaration)} ${countWithRecursiveCalling(declaration)} <= ${limit - 1}`, 'too_long', { declaration, limit })
+  newExpectation(`${countWithRecursiveCalling(declaration)} <= ${limit - 1}`, 'too_long', { declaration, limit })
 
 export const doesNotUseRecursion = (declaration) =>
   newExpectation(`not (through ${toEDLString(declaration)} calls ${toEDLString(declaration)})`, doesNotUseRecursionId, { declaration })
@@ -31,7 +31,7 @@ const newExpectation = (expect, id, opts = {}) =>
   `expectation "${stringify(id, opts)}": ${expect};`
 
 const countWithRecursiveCalling = (declaration) =>
-  `count(calls) + count(calls ${toEDLString(declaration)})`
+  `within ${toEDLString(declaration)} count(calls) + count(calls ${toEDLString(declaration)})`
 
 export const stringify = (id, opts) =>
   `${expectationName(id)}|${Object.entries(opts).map(([key, value]) => `${key}=${value}`).join(';')}`

--- a/app/utils/expectations.js
+++ b/app/utils/expectations.js
@@ -12,7 +12,7 @@ export const multiExpect = (...expectations) => (element) =>
 
 // DECLARATION EXPECTATIONS
 export const doSomething = (declaration) =>
-  newExpectation(`within ${toEDLString(declaration)} count(calls) >= 1`, 'do_something', { declaration })
+  newExpectation(`within ${toEDLString(declaration)} ${countWithRecursiveCalling(declaration)} >= 1`, 'do_something', { declaration })
 
 export const isUsed = (declaration) =>
   newExpectation(`calls ${toEDLString(declaration)}`, 'is_used', { declaration })
@@ -21,7 +21,7 @@ export const isUsedFromMain = (declaration) =>
   newExpectation(`through ${toEDLString(entryPointType)} calls ${toEDLString(declaration)}`, 'is_used_from_main', { declaration })
 
 export const notTooLong = (limit = 7) => (declaration) =>
-  newExpectation(`within ${toEDLString(declaration)} count(calls) <= ${limit - 1}`, 'too_long', { declaration, limit })
+  newExpectation(`within ${toEDLString(declaration)} ${countWithRecursiveCalling(declaration)} <= ${limit - 1}`, 'too_long', { declaration, limit })
 
 export const doesNotUseRecursion = (declaration) =>
   newExpectation(`not (through ${toEDLString(declaration)} calls ${toEDLString(declaration)})`, doesNotUseRecursionId, { declaration })
@@ -29,6 +29,9 @@ export const doesNotUseRecursion = (declaration) =>
 // UTILS
 const newExpectation = (expect, id, opts = {}) =>
   `expectation "${stringify(id, opts)}": ${expect};`
+
+const countWithRecursiveCalling = (declaration) =>
+  `count(calls) + count(calls ${toEDLString(declaration)})`
 
 export const stringify = (id, opts) =>
   `${expectationName(id)}|${Object.entries(opts).map(([key, value]) => `${key}=${value}`).join(';')}`

--- a/app/utils/expectations.js
+++ b/app/utils/expectations.js
@@ -12,7 +12,7 @@ export const multiExpect = (...expectations) => (element) =>
 
 // DECLARATION EXPECTATIONS
 export const doSomething = (declaration) =>
-  newExpectation(`${countCalls(declaration)} >= 1`, 'do_something', { declaration })
+  newExpectation(`${countCallsWithin(declaration)} >= 1`, 'do_something', { declaration })
 
 export const isUsed = (declaration) =>
   newExpectation(`calls ${toEDLString(declaration)}`, 'is_used', { declaration })
@@ -21,7 +21,7 @@ export const isUsedFromMain = (declaration) =>
   newExpectation(`through ${toEDLString(entryPointType)} calls ${toEDLString(declaration)}`, 'is_used_from_main', { declaration })
 
 export const notTooLong = (limit = 7) => (declaration) =>
-  newExpectation(`${countCalls(declaration)} <= ${limit - 1}`, 'too_long', { declaration, limit })
+  newExpectation(`${countCallsWithin(declaration)} <= ${limit - 1}`, 'too_long', { declaration, limit })
 
 export const doesNotUseRecursion = (declaration) =>
   newExpectation(`not (through ${toEDLString(declaration)} calls ${toEDLString(declaration)})`, doesNotUseRecursionId, { declaration })
@@ -32,7 +32,7 @@ export const newExpectation = (expect, id, opts = {}) =>
 
 // Use this to count number of calls inside a procedure, including recursive calls
 // Mulang count does not count recursive calls
-export const countCalls = (declaration) =>
+export const countCallsWithin = (declaration) =>
   `within ${toEDLString(declaration)} count(calls) + count(calls ${toEDLString(declaration)})`
 
 export const stringify = (id, opts) =>

--- a/tests/unit/services/mulang-expectations-test.js
+++ b/tests/unit/services/mulang-expectations-test.js
@@ -29,6 +29,12 @@ module('Unit | Service | Mulang | Expectations', function (hooks) {
     )
   ])
 
+  expectationTestOk('doSomething', doSomething(declaration), [
+    procedure(declaration, [],
+      application(declaration)
+    )
+  ], 'Recursion should count as doing something')
+
   expectationTestFail('doSomething', doSomething('EMPTY'), [
     procedure('EMPTY', [])
   ])
@@ -85,9 +91,17 @@ module('Unit | Service | Mulang | Expectations', function (hooks) {
     )
   ])
 
+  expectationTestFail('notTooLong', notTooLong(limit)(declaration), [
+    procedure(declaration, [],
+      application(declaration),
+      application(declaration),
+      application(declaration)
+    )
+  ], 'Recursive calls should count as being too long ')
+
   expectationTestOk('doesNotUseRecursion', doesNotUseRecursion(declaration), [
     procedure(declaration, [],
-      application("PROCEDURE2")  
+      application("PROCEDURE2")
     ),
     procedure("PROCEDURE2", [])
   ])
@@ -95,31 +109,39 @@ module('Unit | Service | Mulang | Expectations', function (hooks) {
   // Direct recursion
   expectationTestFail('doesNotUseRecursion', doesNotUseRecursion(declaration), [
     procedure(declaration, [],
-      application(declaration)  
+      application(declaration)
     )
   ])
-  /*
+
   // Indirect recursion
   expectationTestFail('doesNotUseRecursion', doesNotUseRecursion(declaration), [
     procedure(declaration, [],
-      application("PROCEDURE2")  
+      application("PROCEDURE2")
     ),
     procedure("PROCEDURE2", [],
       application(declaration)
     )
-  ])
-  */
+  ], 'Indirect recursion should count as recursion')
 
-  function expectationTestOk(expectationName, expectation, astNodes) {
-    expectationTest(expectationName, expectation, astNodes, true)
+  expectationTestFail('doesNotUseRecursion', doesNotUseRecursion(declaration), [
+    procedure(declaration, [],
+      application(declaration),
+      application("PROCEDURE2")
+    ),
+    procedure("PROCEDURE2", [],
+      application('PRIMITIVE'))
+  ], 'Direct recursion with another procedure call should count as recursion')
+
+  function expectationTestOk(expectationName, expectation, astNodes, testName) {
+    expectationTest(expectationName, expectation, astNodes, true, testName)
   }
 
-  function expectationTestFail(expectationName, expectation, astNodes) {
-    expectationTest(expectationName, expectation, astNodes, false)
+  function expectationTestFail(expectationName, expectation, astNodes, testName) {
+    expectationTest(expectationName, expectation, astNodes, false, testName)
   }
 
-  function expectationTest(expectationName, edl, astNodes, shouldPass) {
-    test(`Expectation ${expectationName} - ${shouldPass ? 'ok' : 'fail'}`, function (assert) {
+  function expectationTest(expectationName, edl, astNodes, shouldPass, testName = '') {
+    test(`Expectation ${expectationName} - ${testName || (shouldPass ? 'ok' : 'fail')}`, function (assert) {
       const mulangResult = mulang
         .astCode(rawSequence(astNodes))
         .customExpect(edl)

--- a/tests/unit/services/mulang-expectations-test.js
+++ b/tests/unit/services/mulang-expectations-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit'
 import { entryPointType } from '../../../utils/blocks'
-import { declaresAnyProcedure, doSomething, isUsed, isUsedFromMain, notTooLong, parseExpect, doesNotUseRecursion, stringify, expectationId, isCritical, doesNotUseRecursionId, newExpectation, countCalls } from '../../../utils/expectations'
+import { declaresAnyProcedure, doSomething, isUsed, isUsedFromMain, notTooLong, parseExpect, doesNotUseRecursion, stringify, expectationId, isCritical, doesNotUseRecursionId, newExpectation, countCallsWithin } from '../../../utils/expectations'
 import { procedure, entryPoint, rawSequence, application } from '../../helpers/astFactories'
 import { setupPBUnitTest, setUpTestWorkspace } from '../../helpers/utils'
 
@@ -132,13 +132,13 @@ module('Unit | Service | Mulang | Expectations', function (hooks) {
       application('PRIMITIVE'))
   ], 'Direct recursion with another procedure call should count as recursion')
 
-  expectationTestOk('countCalls', newExpectation(`${countCalls(declaration)} = 2`, 'counts', { declaration }), [
+  expectationTestOk('countCallsWithin', newExpectation(`${countCallsWithin(declaration)} = 2`, 'counts', { declaration }), [
     procedure(declaration, [],
       application("PROCEDURE2"),
       application(declaration)
     ),
     procedure("PROCEDURE2", [])
-  ], 'countCalls includes recursive calls')
+  ], 'countCallsWithin includes recursive calls')
 
   function expectationTestOk(expectationName, expectation, astNodes, testName) {
     expectationTest(expectationName, expectation, astNodes, true, testName)

--- a/tests/unit/services/mulang-expectations-test.js
+++ b/tests/unit/services/mulang-expectations-test.js
@@ -28,13 +28,13 @@ module('Unit | Service | Mulang | Expectations', function (hooks) {
       application('PRIMITIVE')
     )
   ])
-
-  expectationTestOk('doSomething', doSomething(declaration), [
-    procedure(declaration, [],
-      application(declaration)
-    )
-  ], 'Recursion should count as doing something')
-
+  /*
+    expectationTestOk('doSomething', doSomething(declaration), [
+      procedure(declaration, [],
+        application(declaration)
+      )
+    ], 'Recursion should count as doing something')
+  */
   expectationTestFail('doSomething', doSomething('EMPTY'), [
     procedure('EMPTY', [])
   ])
@@ -90,15 +90,15 @@ module('Unit | Service | Mulang | Expectations', function (hooks) {
       application('PRIMITIVE'),
     )
   ])
-
-  expectationTestFail('notTooLong', notTooLong(limit)(declaration), [
-    procedure(declaration, [],
-      application(declaration),
-      application(declaration),
-      application(declaration)
-    )
-  ], 'Recursive calls should count as being too long ')
-
+  /*
+    expectationTestFail('notTooLong', notTooLong(limit)(declaration), [
+      procedure(declaration, [],
+        application(declaration),
+        application(declaration),
+        application(declaration)
+      )
+    ], 'Recursive calls should count as being too long ')
+  */
   expectationTestOk('doesNotUseRecursion', doesNotUseRecursion(declaration), [
     procedure(declaration, [],
       application("PROCEDURE2")

--- a/tests/unit/services/mulang-expectations-test.js
+++ b/tests/unit/services/mulang-expectations-test.js
@@ -28,13 +28,13 @@ module('Unit | Service | Mulang | Expectations', function (hooks) {
       application('PRIMITIVE')
     )
   ])
-  /*
+  
     expectationTestOk('doSomething', doSomething(declaration), [
       procedure(declaration, [],
         application(declaration)
       )
     ], 'Recursion should count as doing something')
-  */
+  
   expectationTestFail('doSomething', doSomething('EMPTY'), [
     procedure('EMPTY', [])
   ])
@@ -90,7 +90,7 @@ module('Unit | Service | Mulang | Expectations', function (hooks) {
       application('PRIMITIVE'),
     )
   ])
-  /*
+  
     expectationTestFail('notTooLong', notTooLong(limit)(declaration), [
       procedure(declaration, [],
         application(declaration),
@@ -98,7 +98,7 @@ module('Unit | Service | Mulang | Expectations', function (hooks) {
         application(declaration)
       )
     ], 'Recursive calls should count as being too long ')
-  */
+  
   expectationTestOk('doesNotUseRecursion', doesNotUseRecursion(declaration), [
     procedure(declaration, [],
       application("PROCEDURE2")

--- a/tests/unit/services/mulang-expectations-test.js
+++ b/tests/unit/services/mulang-expectations-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit'
 import { entryPointType } from '../../../utils/blocks'
-import { declaresAnyProcedure, doSomething, isUsed, isUsedFromMain, notTooLong, parseExpect, doesNotUseRecursion, stringify, expectationId, isCritical, doesNotUseRecursionId } from '../../../utils/expectations'
+import { declaresAnyProcedure, doSomething, isUsed, isUsedFromMain, notTooLong, parseExpect, doesNotUseRecursion, stringify, expectationId, isCritical, doesNotUseRecursionId, newExpectation, countCalls } from '../../../utils/expectations'
 import { procedure, entryPoint, rawSequence, application } from '../../helpers/astFactories'
 import { setupPBUnitTest, setUpTestWorkspace } from '../../helpers/utils'
 
@@ -131,6 +131,14 @@ module('Unit | Service | Mulang | Expectations', function (hooks) {
     procedure("PROCEDURE2", [],
       application('PRIMITIVE'))
   ], 'Direct recursion with another procedure call should count as recursion')
+
+  expectationTestOk('countCalls', newExpectation(`${countCalls(declaration)} = 2`, 'counts', { declaration }), [
+    procedure(declaration, [],
+      application("PROCEDURE2"),
+      application(declaration)
+    ),
+    procedure("PROCEDURE2", [])
+  ], 'countCalls includes recursive calls')
 
   function expectationTestOk(expectationName, expectation, astNodes, testName) {
     expectationTest(expectationName, expectation, astNodes, true, testName)


### PR DESCRIPTION
Al final nos dimos cuenta que el problema no era el AST que estabamos generando sino que la expectativa de doesNotUseRecursion. 

Por lo que entendemos, esta expectativa:

```through `A` ! calls `A` ```

En este workspace:

![image](https://user-images.githubusercontent.com/37090248/162040872-2533dec7-cf12-4a20-a70f-122f1e2f8938.png)

El `through` checkea que exista algun scope transitivo al procedimiento `A` donde ocurra que no se llama a `A`. Esto ocurre en el procedimiento `A`, donde no se esta llamando a `A`, por lo que la expectativa pasa. 


Por esto, al poner el not abarcando todo el `through` estamos checkeando lo que queremos, que es que nunca desde el procedimiento se llegue a llamar a A.



Respecto al otro caso, que era que las llamadas recursivas no estaban siendo contadas como hacer algo, esto parece ser algo propio de Mulang porque al hacer, por ejemplo, ```within `A` count(calls `A`) >= 1```, mulang ahi si detecta las llamadas a del procedimiento a si mismo, pero al hacer ```within `A` count(calls) >= 1``` no.