### PR TITLE
Why are we still here, just to suffer...

### DIFF
--- a/app/components/breadcrumb-item.js
+++ b/app/components/breadcrumb-item.js
@@ -17,4 +17,10 @@ export default Component.extend({
         return _classes;
     }),
 
+    actions: {
+        reload(){
+            window.location.reload()
+        }
+    }
+
 });

--- a/app/components/pilas-blockly.js
+++ b/app/components/pilas-blockly.js
@@ -106,18 +106,7 @@ export default Component.extend({
   async initialWorkspace() {
     const savedSolution = await this.pilasBloquesApi.lastSolution(this.modelActividad.id)
     const serializedURLCode = this.codigo && atob(this.codigo)
-
-    return this.addRandomIdToWorkspace(serializedURLCode || savedSolution?.program || this.modelActividad.initialWorkspace)
-  },
-  /**
-   * Adds an id to a block of the XML.
-   * This is necessary because the ember-blockly component doesnt update the workspace when the
-   * initial workspace is the same as the previous challenge. 
-   */
-  addRandomIdToWorkspace(workspaceXML) {
-    return workspaceXML && (workspaceXML.includes('id=') ?
-      workspaceXML.replace(/id="[^"]*"/, `id="${Blockly.utils.genUid()}"`) :
-      workspaceXML.replace('<block', `<block id="${Blockly.utils.genUid()}"`))
+    return serializedURLCode || savedSolution?.program || this.modelActividad.initialWorkspace  
   },
 
   /**

--- a/app/templates/components/breadcrumb-item.hbs
+++ b/app/templates/components/breadcrumb-item.hbs
@@ -1,7 +1,7 @@
 {{#if (or initial (and item item.titulo))}}
     <li class={{classes}}>
         {{#if href}}
-            <a href={{href}}>{{yield}}{{item.titulo}}</a>
+            <a href={{href}} onClick={{if @shouldReload (action 'reload')}}>{{yield}}{{item.titulo}}</a>
         {{else}}
             <a>{{yield}}{{item.titulo}}</a>
         {{/if}}

--- a/app/templates/components/button-to-challenge.hbs
+++ b/app/templates/components/button-to-challenge.hbs
@@ -1,3 +1,4 @@
+
 <Breadcrumb>
-    <BreadcrumbItem @href={{href-to "desafio" challenge.id (query-params codigo="")}} @initial={{true}}>{{yield}}</BreadcrumbItem>
+    <BreadcrumbItem @shouldReload={{true}} @href={{href-to "desafio" challenge.id (query-params codigo="")}} @initial={{true}}>{{yield}}</BreadcrumbItem>
 </Breadcrumb>

--- a/package-lock.json
+++ b/package-lock.json
@@ -26835,6 +26835,7 @@
         "abbrev": "1.0.x",
         "async": "0.2.x",
         "escodegen": "1.2.x",
+        "esprima": "esprima@git://github.com/ariya/esprima.git#harmony",
         "fileset": "0.1.x",
         "handlebars": "1.3.x",
         "js-yaml": "3.x",
@@ -26873,7 +26874,8 @@
         },
         "esprima": {
           "version": "git+ssh://git@github.com/ariya/esprima.git#a65a3eb93b9a5dce9a1184ca2d1bd0b184c6b8fd",
-          "from": "esprima@git://github.com/ariya/esprima.git#harmony"
+          "from": "esprima@git://github.com/ariya/esprima.git#harmony",
+          "optional": true
         },
         "estraverse": {
           "version": "1.5.1",
@@ -34560,6 +34562,12 @@
         "immutable": "^4.0.0",
         "source-map-js": ">=0.6.2 <2.0.0"
       }
+    },
+    "sass-migrator": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/sass-migrator/-/sass-migrator-1.5.4.tgz",
+      "integrity": "sha512-KPnoY84/dKYPW5TW6qXASR3yOpap4+tPfCygzNKhaodg3cF+dwlyTwnbJj0QZd64nQD8g7RsicFbqSG6ts0WlQ==",
+      "dev": true
     },
     "sax": {
       "version": "1.2.1",


### PR DESCRIPTION
Fix #956 

_Todo problema se puede solucionar con un **hard window reload**... (Ember.js Dev # 3, December 9, 2011)_

Cuando se crearon los `NextChallengeButtons` que nos permitían movernos entre desafíos, surgió el problema de que, si la actividad a la que te vas a mover inicia con un _workspace_ igual a la actividad anterior, el estado del mismo no se reiniciaba. Por lo que quedaba la solución anterior cargada.

Para solucionar esto, dentro del hook `didInsertElement` de Ember en el componente `pilas-blockly`, se volvió a settear el _workspace_ original pero agregándole un id random, de manera que se reinicie el estado del _workspace_ original.

Pero esto trae algunos problemas ya que el componente se vuelve a renderizar por varias razones, no _solamente_ porque se cambió de desafío. Por ejemplo: cuando se cambia a pantalla completa. Por lo que el setteo del id no debería estar en ese lugar.

Con @tfloxolodeiro quisimos hacer que, además de que se cambie el link de la actividad, se setee el _initial workspace_ como se hacía antes (agregándole el id para que se pueda reiniciar su estado). Pero para eso, desde los botones deberíamos poder conocer al componente `pilas-blockly` para poder enviarles el mensaje. Y eso es bastante engorroso.

Por lo que fuimos por _la vieja confiable_ y decidimos hacer un refresh de la página para que se reinicia el estado del workspace.
