### PR TITLE
Code lost hotfix

### DIFF
--- a/app/components/pilas-blockly.js
+++ b/app/components/pilas-blockly.js
@@ -85,17 +85,7 @@ export default Component.extend({
     const savedSolution = await this.pilasBloquesApi.lastSolution(this.modelActividad.id)
     const serializedURLCode = this.codigo && atob(this.codigo)
 
-    return this.addRandomIdToWorkspace(serializedURLCode || savedSolution?.program || this.modelActividad.initialWorkspace)
-  },
-  /**
-   * Adds an id to a block of the XML.
-   * This is necessary because the ember-blockly component doesnt update the workspace when the
-   * initial workspace is the same as the previous challenge. 
-   */
-  addRandomIdToWorkspace(workspaceXML) {
-    return workspaceXML && (workspaceXML.includes('id=') ?
-      workspaceXML.replace(/id="[^"]*"/, `id="${Blockly.utils.genUid()}"`) :
-      workspaceXML.replace('<block', `<block id="${Blockly.utils.genUid()}"`))
+    return serializedURLCode || savedSolution?.program || this.modelActividad.initialWorkspace
   },
 
   /**

--- a/app/routes/desafio.js
+++ b/app/routes/desafio.js
@@ -12,6 +12,15 @@ export default Route.extend({
   model(param) {
     this.store.findAll("libro");
     return this.store.findRecord('desafio', param.desafio_id);
+  },
+
+  actions: {
+    willTransition(transition) {
+      const challengeKey = 'desafio_id'
+      const challengeIdFrom = transition.from.params[challengeKey]
+      const challengeIdTo = transition.to.params[challengeKey]
+      if(challengeIdFrom !== challengeIdTo) window.location.reload()
+    }
   }
 
 });


### PR DESCRIPTION
Fixes #956

Linkeo el PR anterior: https://github.com/Program-AR/pilas-bloques/pull/975

La estrategia del `beforeModel` no funciona porque, si hacemos un reload dentro de ese _hook_ recarga la página y vuelve a llamar al _hook_. Quedamos en un reload infinito hermoso.

La otra estrategia lo resuelve y ya no es necesario crear una action para poder recargar la página.