### PR TITLE
Custom categories are back

### DIFF
--- a/app/components/pilas-blockly.js
+++ b/app/components/pilas-blockly.js
@@ -138,14 +138,33 @@ export default Component.extend({
   },
 
   groupedByCategories(blockTypes) {
-    return this.categoryIdsFor(blockTypes).map(categoryId => ({
-      categoryId: categoryId,
-      blocks: blockTypes.filter(bt => this._categoryIdFor(bt) === categoryId),
-    }))
+    return this.groupByCategories(blockTypes.map(bt => this.toolboxBlock(bt)))
   },
 
-  categoryIdsFor(blockTypes) {
-    return [... new Set(blockTypes.map(bt => this._categoryIdFor(bt)))]
+  toolboxBlock(blockType) {
+    const toolboxBlock = {
+      categoryId: this._categoryIdFor(blockType),
+      blocks: [blockType]
+    }
+    const blocklyBlock = this.blocklyBlock(blockType)
+    if(blocklyBlock?.categoria_custom) toolboxBlock.custom = blocklyBlock.categoria_custom
+    return toolboxBlock
+  },
+
+  groupByCategories(toolboxBlocks) {
+    const groupedBlocks = []
+    toolboxBlocks.forEach(tb => {
+      const match = groupedBlocks.find(gb => gb.categoryId === tb.categoryId) 
+      if(match) {
+        match.blocks.push(...tb.blocks)
+        if(tb.custom) match.custom = tb.custom  //Last one takes precedence
+      }
+      else {
+        groupedBlocks.push(tb)
+      }
+    })
+
+    return groupedBlocks
   },
 
   _categoryIdFor(blockType) {

--- a/tests/unit/components/pilas-blockly-test.js
+++ b/tests/unit/components/pilas-blockly-test.js
@@ -418,4 +418,81 @@ module('Unit | Components | pilas-blockly | ToolboxForBlockTypes', function (hoo
     assert.propEqual(this.ctrl._toEmberBlocklyToolboxItem(category), emberCategory)
   })
 
+  test('toolboxBlock without custom category', function (assert) {
+    const blockType = 'MoverACasillaDerecha'
+    const blockWithoutCustomCategory = {
+      categoryId: 'primitives',
+      blocks: [blockType]
+    }
+    assert.propEqual(this.ctrl.toolboxBlock(blockType), blockWithoutCustomCategory)
+  })
+
+  test('toolboxBlock with custom category', function (assert) {
+    const blockType = 'Procedimiento'
+    const blockWithCustomCategory = {
+      categoryId: 'myProcedures',
+      blocks: [blockType],
+      custom: 'PROCEDURE'
+    }
+    assert.propEqual(this.ctrl.toolboxBlock(blockType), blockWithCustomCategory)
+  })
+
+  test('group by categories without custom categories', function (assert) {
+    const moveRight = 'MoverACasillaDerecha'
+    const moveLeft = 'MoverACasillaIzquierda'
+    const repeat = 'Repetir'
+    const primitives = 'primitives'
+    const repetitions = 'repetitions'
+    const moveRightToolboxBlock = {
+      categoryId: primitives,
+      blocks: [moveRight]
+    }
+    const moveLeftToolboxBlock = {
+      categoryId: primitives,
+      blocks: [moveLeft]
+    }
+    const repeatToolboxBlock = {
+      categoryId: repetitions,
+      blocks: [repeat]
+    }
+    const groupedPrimitives = {
+      categoryId: primitives,
+      blocks: [moveRight, moveLeft]
+    }
+    const groupedRepetitions = {
+      categoryId: repetitions,
+      blocks: [repeat]
+    }
+    assert.propEqual(
+      this.ctrl.groupByCategories([moveRightToolboxBlock, moveLeftToolboxBlock, repeatToolboxBlock]),
+      [groupedPrimitives, groupedRepetitions]
+    )
+  })
+
+  test('group by categories with custom categories should prioritize last value', function (assert) {
+    const myProcedures = 'myProcedures'
+    const aProcedure = 'A procedure'
+    const otherProcedure = 'Other procedure'
+    const customWithPriority = 'CUSTOM'
+    const aProcedureToolboxBlock = {
+      categoryId: myProcedures,
+      blocks: [aProcedure],
+      custom: 'EMPTY'
+    }
+    const otherProcedureToolboxBlock = {
+      categoryId: myProcedures,
+      blocks: [otherProcedure],
+      custom: customWithPriority
+    }
+    const groupedBlocks = {
+      categoryId: myProcedures,
+      blocks: [aProcedure, otherProcedure],
+      custom: customWithPriority
+    }
+    assert.propEqual(
+      this.ctrl.groupByCategories([aProcedureToolboxBlock, otherProcedureToolboxBlock]),
+      [groupedBlocks]
+    )
+  })
+
 })


### PR DESCRIPTION
Fixes #990 

![image](https://user-images.githubusercontent.com/31800576/169144106-64a37870-d11d-45f4-9bae-761f8e151977.png)

Cuando hice el refactor del toolbox me olvidé de un pequeño detalle: https://github.com/Program-AR/pilas-bloques/blob/78a61587b883dcf171c2350d820fb25b913c81d5/app/components/pilas-blockly.js#L225-L247

Si existía una categoría custom se agregaba. Y se quedaba con la última que encontraba.

Terminé cambiando la estrategia que teníamos antes porque era un poco incómodo poder acceder al blocktype luego de haberlos transformado a _ids de categorías_. Ahora separé la parte del agrupamiento en dos partes: una transformación inicial y luego su agrupación. Aunque capaz terminó quedando un poco más feito.
