### PR TITLE
Warning line wrap and icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # compiled output
-/dist
-/dist_prod
+/dist*
 /tmp
 
 .DS_Store

--- a/app/utils/blocks.js
+++ b/app/utils/blocks.js
@@ -95,13 +95,27 @@ export function clearValidationsFor(block) {
   block.setWarningText(null)
 }
 
-export function addWarning(block, message, index) {
-  block.setWarningText(message, index)
+export function addWarning(block, message, index, itemChar = '☆ ') {
+  block.setWarningText(itemChar + lineWrap(message), index)
   block.warning.setVisible(true)
   block.warning.bubble_.setColour('yellow')
 }
 
 export function addError(block, message, index) {
-  addWarning(block, message, index)
+  addWarning(block, message, index, '★ ')
   block.warning.bubble_.setColour('red')
+}
+
+function lineWrap(message){
+  const lineLen = 75
+  return message.split(' ').reduce((lines, word) => {
+      const lastLine = lines[lines.length-1]
+      if(lastLine.length + word.length > lineLen)
+        lines.push(word)
+      else
+        lines.push(lines.pop() + ' ' + word)
+      return lines
+    },
+    [""]
+  ).join('\n  ')
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26846,7 +26846,6 @@
         "abbrev": "1.0.x",
         "async": "0.2.x",
         "escodegen": "1.2.x",
-        "esprima": "esprima@git://github.com/ariya/esprima.git#harmony",
         "fileset": "0.1.x",
         "handlebars": "1.3.x",
         "js-yaml": "3.x",
@@ -26885,8 +26884,7 @@
         },
         "esprima": {
           "version": "git+ssh://git@github.com/ariya/esprima.git#a65a3eb93b9a5dce9a1184ca2d1bd0b184c6b8fd",
-          "from": "esprima@git://github.com/ariya/esprima.git#harmony",
-          "optional": true
+          "from": "esprima@git://github.com/ariya/esprima.git#harmony"
         },
         "estraverse": {
           "version": "1.5.1",

--- a/tests/helpers/utils.js
+++ b/tests/helpers/utils.js
@@ -159,7 +159,7 @@ export function assertNotDisabled(assert, block) {
 }
 
 export function assertWarning(assert, block, warning) {
-    assert.equal(block.warning.getText(), warning)
+    assert.ok(block.warning.getText().includes(warning), `El warning "${block.warning.getText()}" debería contener lo esperado: "${warning}"`)
 }
 
 export function assertNotWarning(assert, block) {

--- a/tests/unit/services/blocks-gallery-test.js
+++ b/tests/unit/services/blocks-gallery-test.js
@@ -148,7 +148,7 @@ module('Unit | Service | blocks-gallery', function (hooks) {
   test('Parameter in parent procedure without param should be disabled', function (assert) {
     let param = findParam(Blockly.textToBlock(procedureWithDeletedParam))
     assert.ok(param.disabled)
-    assert.equal(param.warning.getText(), "Este bloque ya no puede usarse, el parámetro ha sido eliminado.")
+    assertWarning(assert, param, "Este bloque ya no puede usarse, el parámetro ha sido eliminado.")
   });
 
 

--- a/tests/unit/services/blocks-gallery-test.js
+++ b/tests/unit/services/blocks-gallery-test.js
@@ -180,7 +180,7 @@ module('Unit | Service | blocks-gallery', function (hooks) {
     Blockly.textToBlock(emptyProcedure)
     let param = findParam(Blockly.textToBlock(main))
     assertDisabled(assert, param)
-    assertWarning(assert, param, 'Este bloque no puede usarse aquí. Es un parámetro que sólo puede usarse en el procedimiento "Hacer algo"')
+    assertWarning(assert, param, 'Este bloque no puede usarse aquí. Es un parámetro que sólo puede usarse en\n  el procedimiento "Hacer algo"')
   });
 
 


### PR DESCRIPTION
Fixes #1012 

![Selection_028](https://user-images.githubusercontent.com/5421992/170801633-980a239b-94ac-416b-bc8c-5581b07a13f8.png)
![Selection_031](https://user-images.githubusercontent.com/5421992/170801652-a86e843f-b23d-43d5-8b22-72434aa0bf40.png)

Resuelto jugando con strings, porque el `setWarningText` de blockly básicamente plancha un string dentro de un tag `<text>` **en un SVG**, así que no hay mucho que hacer sin meterse dentro de blockly.

Ah, se le puede cambiar el estilo a ese texto jugando justamente con css a ponerle estilo a los tags `<text>` y `<tspan>` pero no se me ocurrió nada interesante para jugar... Avisen si se les ocurre algo:

![Selection_032](https://user-images.githubusercontent.com/5421992/170802066-cbdfc473-7776-40c3-8647-f87920f742d5.png)

