### PR TITLE
Separando errores de warnings

### DIFF
--- a/app/components/pilas-blockly.js
+++ b/app/components/pilas-blockly.js
@@ -399,12 +399,14 @@ export default Component.extend({
     })
   },
 
-  showBlocksExpectationFeedback() {
-    // Order is important. Warnings should be added first. This way, if errors appear, warning bubbles will be painted red.
+  showBlocksWarningExpectationFeedback() {
     this.showExpectationFeedbackFor(
       notCritical,
       addWarning
     )
+  },
+
+  showBlocksErrorExpectationFeedback(){
     this.showExpectationFeedbackFor(
       isCritical,
       addError
@@ -422,7 +424,9 @@ export default Component.extend({
   async runValidations() {
     clearValidations()
     this.set('expects', await this.pilasMulang.analyze(Blockly.mainWorkspace, this.challenge))
-    if(this.experiments.shouldShowBlocksExpectationFeedback()) this.showBlocksExpectationFeedback()
+    // Order is important. Warnings should be added first. This way, if errors appear, warning bubbles will be painted red.
+    if(this.experiments.shouldShowBlocksWarningExpectationFeedback()) this.showBlocksWarningExpectationFeedback()
+    this.showBlocksErrorExpectationFeedback()
     Blockly.Events.fireRunCode()
   },
 

--- a/app/services/experiments.js
+++ b/app/services/experiments.js
@@ -45,7 +45,7 @@ export default Service.extend({
     return this.isNotAffected()
   },
 
-  shouldShowBlocksExpectationFeedback(){
+  shouldShowBlocksWarningExpectationFeedback(){
     return this.isTreatmentGroup() && !this.feedbackIsDisabled()
   },
 

--- a/tests/helpers/mocks.js
+++ b/tests/helpers/mocks.js
@@ -95,11 +95,11 @@ export const experimentsMock = Service.extend({
 
     shouldShowExpectsFeedback: false,
 
-    setShouldShowBlocksExpectationFeedback(value) {
+    setShouldShowBlocksWarningExpectationFeedback(value) {
         this.shouldShowExpectsFeedback = value
     },
 
-    shouldShowBlocksExpectationFeedback() { return this.shouldShowExpectsFeedback },
+    shouldShowBlocksWarningExpectationFeedback() { return this.shouldShowExpectsFeedback },
 
     updateSolvedChallenges() { }
 })

--- a/tests/unit/components/pilas-blockly-test.js
+++ b/tests/unit/components/pilas-blockly-test.js
@@ -301,7 +301,7 @@ module('Unit | Components | pilas-blockly', function (hooks) {
     }
 
     test('Should show expectation feedback bubbles when required by experiments', async function (assert) {
-      experimentsMock.setShouldShowBlocksExpectationFeedback(true)
+      experimentsMock.setShouldShowBlocksWarningExpectationFeedback(true)
 
       this.ctrl.send('ejecutar')
       const required = blockFromProgram(failingExpectationsProgram)
@@ -310,7 +310,7 @@ module('Unit | Components | pilas-blockly', function (hooks) {
     })
 
     test('Should not show expectation feedback bubbles when not required by experiments', async function (assert) {
-      experimentsMock.setShouldShowBlocksExpectationFeedback(false)
+      experimentsMock.setShouldShowBlocksWarningExpectationFeedback(false)
 
       this.ctrl.send('ejecutar')
       const required = blockFromProgram(failingExpectationsProgram)

--- a/tests/unit/services/experiments-test.js
+++ b/tests/unit/services/experiments-test.js
@@ -43,9 +43,9 @@ module('Unit | Service | experiments', function (hooks) {
 
   //Show feedback expectations (bubbles)
 
-  testShouldShowBlocksExpectationsFeedback('control', 'enabled', false)
-  testShouldShowBlocksExpectationsFeedback('treatment', 'enabled', true)
-  testShouldShowBlocksExpectationsFeedback('treatment', 'disabled', false, solvedChallengesFeedbackDisabled)
+  testShouldShowBlocksWarningExpectationsFeedback('control', 'enabled', false)
+  testShouldShowBlocksWarningExpectationsFeedback('treatment', 'enabled', true)
+  testShouldShowBlocksWarningExpectationsFeedback('treatment', 'disabled', false, solvedChallengesFeedbackDisabled)
 
 
   //Congratulations modal
@@ -97,8 +97,8 @@ module('Unit | Service | experiments', function (hooks) {
     testShouldShow('scored expects', group, feedback, shouldShow, (() => experiments.shouldShowScoredExpectations()), solvedChallenges)
   }
 
-  function testShouldShowBlocksExpectationsFeedback(group, feedback, shouldShow, solvedChallenges){
-    testShouldShow('blocks expectation feedback', group, feedback, shouldShow, (() => experiments.shouldShowBlocksExpectationFeedback()), solvedChallenges)
+  function testShouldShowBlocksWarningExpectationsFeedback(group, feedback, shouldShow, solvedChallenges){
+    testShouldShow('blocks warning expectation feedback', group, feedback, shouldShow, (() => experiments.shouldShowBlocksWarningExpectationFeedback()), solvedChallenges)
   }
 
   function testShouldShow(name, group, feedback, shouldShow, callback, solvedChallenges = []){


### PR DESCRIPTION
Related #1060 

Plot twist, esto ya estaba hecho. **peeeero**, en el grupo de control y cuando se desactivaban las expectativas, se dejaba de mostrar los warnings incluyendo a la expectativa crítica (que no deja ejecutar) de cuando se usa recursión. 
¿Queremos que tampoco se muestre en estos casos? Si la respuesta es sí, este PR puede ser cerrado y aquí nadie vió nada :eyes:; si no, dividí el agregado del feedback en warnings y errores de expectativas, para que siempre se muestren los errores, más allá del grupo, o si está o no está activado el feedback:

https://github.com/Program-AR/pilas-bloques/blob/97b68f869c901daa42052fb07a352138b10f2fd3/app/components/pilas-blockly.js#L424-L431