### PR TITLE
Algunas cositas que quedaron por corregir

### DIFF
--- a/app/components/pilas-blockly.js
+++ b/app/components/pilas-blockly.js
@@ -411,25 +411,22 @@ export default Component.extend({
       notCritical,
       addWarning
     )
-  },
-
-  showBlocksErrorExpectationFeedback(){
+    
     this.showExpectationFeedbackFor(
       warningInControlStructureBlock,
       addWarning,
       getNestedControlStructureBlocks
     )
+  },
+
+  showBlocksErrorExpectationFeedback(){
     this.showExpectationFeedbackFor(
       isCritical,
       addError
     )
   },
 
-  declarationWithNameToArray(declaration){
-    return [declarationWithName(declaration)]
-  },
-
-  showExpectationFeedbackFor(condition, addFeedback, getBlocks = this.declarationWithNameToArray) {
+  showExpectationFeedbackFor(condition, addFeedback, getBlocks = (n) => [declarationWithName(n)]) {
     this.get('failedExpects')
       .filter(condition)
       .forEach(({ declaration, description }, i) => {

--- a/app/services/challenge-expectations.js
+++ b/app/services/challenge-expectations.js
@@ -1,6 +1,6 @@
 import Service from '@ember/service'
 import { isEmpty/*, compose*/ } from 'ramda'
-import { allProceduresShould, declaresAnyProcedure, doesNotUseRecursion, doSomething, isUsed, isUsedFromMain, multiExpect, notTooLong, mainNotTooLong, noExpectation, nameWasChanged, doesNotNestControlStructures } from '../utils/expectations'
+import { allProceduresShould, doesNotUseRecursion, doSomething, isUsed, isUsedFromMain, multiExpect, notTooLong, mainNotTooLong, noExpectation, nameWasChanged, doesNotNestControlStructures } from '../utils/expectations'
 import { inject as service } from '@ember/service';
 
 const idsToExpectations = (intl) => ({

--- a/app/utils/expectations.js
+++ b/app/utils/expectations.js
@@ -31,7 +31,7 @@ export const doSomething = (declaration) =>
 
 export const declarationDoesNotNestControlStructures = (declaration) => 
   newExpectation(
-    {isSuggestion: true, isForControlGroup: true, isScoreable: true, warningInControlStructureBlock: true},
+    {isSuggestion: true, isForControlGroup: true, isScoreable: true},
     `within ${toEDLString(declaration)} ${nestedAlternativeStructureEDL} && ${nestedControlStructureEDL('repeat')} && ${nestedControlStructureEDL('while')}`, doesNotNestControlStructuresId, { declaration })
 
 export const isUsed = (declaration) =>
@@ -137,7 +137,7 @@ export const isCritical = (expectationResult) => expectationResult && expectatio
 
 export const notCritical = (expectationResult) => !isCritical(expectationResult) && !warningInControlStructureBlock(expectationResult)
 
-export const warningInControlStructureBlock = (expectationResult) => expectationResult && expectationResult.warningInControlStructureBlock
+export const warningInControlStructureBlock = (expectationResult) => expectationResult.id == doesNotNestControlStructuresId
 
 export const isUsageResult = (expectationResult) => expectationResult && expectationResult.isRelatedToUsage
 

--- a/tests/helpers/mocks.js
+++ b/tests/helpers/mocks.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object'
 import Service from '@ember/service';
 import sinon from 'sinon';
-import { allProceduresShould, declaresAnyProcedure, doesNotUseRecursion, doSomething, isUsed, isUsedFromMain, multiExpect, notTooLong, nameWasChanged, usesConditionalAlternative, usesConditionalRepetition, usesSimpleRepetition } from '../../utils/expectations'
+import { allProceduresShould, doesNotUseRecursion, doSomething, isUsed, isUsedFromMain, multiExpect, notTooLong, nameWasChanged, usesConditionalAlternative, usesConditionalRepetition, usesSimpleRepetition } from '../../utils/expectations'
 import { entryPointType } from '../../utils/blocks'
 
 export const pilasMock = Service.extend({
@@ -115,7 +115,6 @@ export const createGroup = (owner, fields) => {
 
 export const idsToExpectationsMock = (intl) => ({
     decomposition: multiExpect(
-        declaresAnyProcedure,
         () => notTooLong()(entryPointType),
         allProceduresShould(
             notTooLong(),

--- a/tests/unit/components/pilas-blockly-test.js
+++ b/tests/unit/components/pilas-blockly-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit'
 import { setupTest } from 'ember-qunit'
 import { pilasMock, interpreterFactoryMock, interpreteMock, actividadMock, blocklyWorkspaceMock, componentMock, challengeExpectationsMock, experimentsMock, challengeWithExpectationsMock, idsToExpectationsMock } from '../../helpers/mocks'
 import { findBlockByTypeIn, assertProps, assertWarning, assertNotWarning, assertHasProps, setUpTestLocale } from '../../helpers/utils'
-import { /*nameWasChanged,*/ doesNotUseRecursionId } from '../../../utils/expectations'
+import { usesSimpleRepetition, doesNotUseRecursionId } from '../../../utils/expectations'
 import sinon from 'sinon'
 import { settled } from '@ember/test-helpers';
 
@@ -239,15 +239,15 @@ module('Unit | Components | pilas-blockly', function (hooks) {
       assert.notOk(this.ctrl.shouldExecuteProgram())
     })
 
-/*     test('Al resolver el problema con expectativas fallidas', async function (assert) { 
-      Blockly.textToBlock(nonFilledProcedure)
-      this.owner.lookup('service:challengeExpectations').expectations = nameWasChanged
+    test('Al resolver el problema con expectativas fallidas', async function (assert) { 
+      Blockly.textToBlock(filledProgram)
+      this.owner.lookup('service:challengeExpectations').expectations = usesSimpleRepetition
       this.ctrl.send('ejecutar')
       await settled()
       later(() => {
         assert.notOk(this.ctrl.get('allExpectsPassed'))
       })
-    }) */
+    })
 
     test('Al resolver el problema sin expectativas fallidas', async function (assert) {
       this.ctrl.send('ejecutar')

--- a/tests/unit/components/pilas-blockly-test.js
+++ b/tests/unit/components/pilas-blockly-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit'
 import { setupTest } from 'ember-qunit'
 import { pilasMock, interpreterFactoryMock, interpreteMock, actividadMock, blocklyWorkspaceMock, componentMock, challengeExpectationsMock, experimentsMock, challengeWithExpectationsMock, idsToExpectationsMock } from '../../helpers/mocks'
 import { findBlockByTypeIn, assertProps, assertWarning, assertNotWarning, assertHasProps, setUpTestLocale } from '../../helpers/utils'
-import { declaresAnyProcedure, doesNotUseRecursionId } from '../../../utils/expectations'
+import { /*nameWasChanged,*/ doesNotUseRecursionId } from '../../../utils/expectations'
 import sinon from 'sinon'
 import { settled } from '@ember/test-helpers';
 
@@ -239,15 +239,15 @@ module('Unit | Components | pilas-blockly', function (hooks) {
       assert.notOk(this.ctrl.shouldExecuteProgram())
     })
 
-    test('Al resolver el problema con expectativas fallidas', async function (assert) {
-      Blockly.textToBlock(filledProgram)
-      this.owner.lookup('service:challengeExpectations').expectations = declaresAnyProcedure
+/*     test('Al resolver el problema con expectativas fallidas', async function (assert) { 
+      Blockly.textToBlock(nonFilledProcedure)
+      this.owner.lookup('service:challengeExpectations').expectations = nameWasChanged
       this.ctrl.send('ejecutar')
       await settled()
       later(() => {
         assert.notOk(this.ctrl.get('allExpectsPassed'))
       })
-    })
+    }) */
 
     test('Al resolver el problema sin expectativas fallidas', async function (assert) {
       this.ctrl.send('ejecutar')

--- a/tests/unit/services/mulang-expectations-test.js
+++ b/tests/unit/services/mulang-expectations-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit'
 import { entryPointType } from '../../../utils/blocks'
-import { declaresAnyProcedure, doSomething, isUsed, isUsedFromMain, notTooLong, parseExpect, doesNotUseRecursion, stringify, isCritical, doesNotUseRecursionId, newExpectation, countCallsWithin, nameWasChanged, usesConditionalAlternative, usesConditionalRepetition, usesSimpleRepetition, declarationDoesNotNestControlStructures } from '../../../utils/expectations'
+import { doSomething, isUsed, isUsedFromMain, notTooLong, parseExpect, doesNotUseRecursion, stringify, isCritical, doesNotUseRecursionId, newExpectation, countCallsWithin, nameWasChanged, usesConditionalAlternative, usesConditionalRepetition, usesSimpleRepetition, declarationDoesNotNestControlStructures } from '../../../utils/expectations'
 import { procedure, entryPoint, rawSequence, application, muIf, ifElse, none, muUntil, repeat, number } from '../../helpers/astFactories'
 import { setupPBUnitTest, setUpTestWorkspace } from '../../helpers/utils'
 
@@ -12,16 +12,7 @@ module('Unit | Service | Mulang | Expectations', function (hooks) {
   const limit = '3'
 
   // EDL
-  expectationTestOk('declaresAnyProcedure', declaresAnyProcedure(), [
-    entryPoint(entryPointType),
-    procedure('EMPTY', [])
-  ])
-
-  expectationTestFail('declaresAnyProcedure', declaresAnyProcedure(), [
-    entryPoint(entryPointType)
-  ])
-
-
+ 
   expectationTestOk('doSomething', doSomething(declaration), [
     procedure(declaration, [],
       application('PRIMITIVE')

--- a/tests/unit/services/mulang-expectations-test.js
+++ b/tests/unit/services/mulang-expectations-test.js
@@ -296,7 +296,7 @@ module('Unit | Service | Mulang | Expectations', function (hooks) {
   )
 
   expectationKeyTest('doesNotNestControlStructures', declarationDoesNotNestControlStructures(declaration),
-    ['does_not_nest_control_structures', { declaration, isSuggestion: true, isScoreable: true, isForControlGroup: true, warningInControlStructureBlock: true}]
+    ['does_not_nest_control_structures', { declaration, isSuggestion: true, isScoreable: true, isForControlGroup: true}]
   )
 
   expectationKeyTest('usesConditionalAlternative', usesConditionalAlternative(),


### PR DESCRIPTION
* Fix de los tests que rompían en develop (por `declaresAnyProcedure`) 
* Sugerencias de: https://github.com/Program-AR/pilas-bloques/pull/1047
* Habían los warnings de anidaciones dentro de los errores de expectativas al momento de mostrarlos en los bloques, en lugar de con los demás warnings, por lo que se estaban mostrando siempre (todos los grupos).