### PR TITLE
Error in static analysis + bug 

### DIFF
--- a/app/components/pilas-blockly.js
+++ b/app/components/pilas-blockly.js
@@ -31,6 +31,8 @@ export default Component.extend({
   expects: [],
   codigoActualEnFormatoXML: '',     // se actualiza automáticamente al modificar el workspace.
 
+  staticAnalysisError: '',
+
   anterior_ancho: -1,
   anterior_alto: -1,
 
@@ -378,7 +380,8 @@ export default Component.extend({
       score: {
         expectResults: this.scoredExpectsResults(),
         percentage: this.expectsScoring.totalScore(this.get('expects'), this.challenge)
-      }
+      },
+      error: this.get('staticAnalysisError')
     }
   },
 
@@ -459,9 +462,17 @@ export default Component.extend({
   actions: {
 
     async ejecutar(pasoAPaso = false) {
-      const analyticsSolutionId = this.runProgramEvent()
+      this.set('staticAnalysisError', '')
       await this.pilasService.restartScene()
-      await this.runValidations()
+
+      try {
+        await this.runValidations()
+      } catch(e) {
+        console.log(e)
+        this.set('staticAnalysisError', e.toString())
+      }
+      
+      const analyticsSolutionId = this.runProgramEvent()
 
       if (!this.shouldExecuteProgram()) return;
 

--- a/tests/unit/components/pilas-blockly-test.js
+++ b/tests/unit/components/pilas-blockly-test.js
@@ -380,8 +380,8 @@ module('Unit | Components | pilas-blockly', function (hooks) {
       Blockly.textToBlock(filledProgram)
       this.ctrl.send('onChangeWorkspace', filledProgram) // Fire property change :(
       this.ctrl.send('ejecutar')
-      const metadata = this.ctrl.pilasBloquesApi.runProgram.lastCall.lastArg
       await settled()
+      const metadata = this.ctrl.pilasBloquesApi.runProgram.lastCall.lastArg
       assertHasProps(assert, metadata, 'ast', 'staticAnalysis', 'turboModeOn', 'program')
       assert.deepEqual(metadata.staticAnalysis, {
         couldExecute: true,
@@ -389,7 +389,8 @@ module('Unit | Components | pilas-blockly', function (hooks) {
         score: {
           expectResults: [solutionWorksResult],
           percentage: 100
-        }
+        },
+        error: ''
       })
     })
 
@@ -412,8 +413,8 @@ module('Unit | Components | pilas-blockly', function (hooks) {
 
     test('On running should send the metadata to the API', async function (assert) {
       this.ctrl.send('ejecutar')
-      const metadata = this.ctrl.pilasBloquesApi.runProgram.lastCall.lastArg
       await settled()
+      const metadata = this.ctrl.pilasBloquesApi.runProgram.lastCall.lastArg
       assertHasProps(assert, metadata, 'ast', 'staticAnalysis', 'turboModeOn',)
       assert.ok(metadata.program || metadata.program.length === 0)
     })


### PR DESCRIPTION
Resolves #1116 

Pilas-bloques-models: https://github.com/Program-AR/pilas-bloques-models/pull/9tfl

Probando que guarde bien el static analysis me di cuenta que el score no se está guardando bien para los ejercicios que tienen decomposition pero no tienen estructuras de control.
Al no haber estructuras de control, no se corre esa expectativa (no hay procedimientos que necesiten correrla), haciendo que hayan "menos" expectativas cumplidas de las que debería haber y el tope del score (cuando está todo perfecto) quede en 83,3 en lugar de 100.