### PR TITLE
Mulang tildes

### DIFF
--- a/app/services/pilas-mulang.js
+++ b/app/services/pilas-mulang.js
@@ -75,7 +75,7 @@ export const combineUsage = (resultGroup) => {
  * @returns a Pilas Bloques Expectation Result object
  */
 const toExpectationResult = (intl) => ([expect, result]) => {
-  const [name, params] = parseExpect(expect)
+  const [name, params] = parseExpect(atob(expect))  //Expectation name (expect) is encoded to prevent errors when using accent marks: https://github.com/Program-AR/pilas-bloques/issues/1096
   return {
     id: name,
     description: expectationDescription(intl, name, result, params),

--- a/app/utils/expectations.js
+++ b/app/utils/expectations.js
@@ -72,8 +72,9 @@ export const nameWasChanged = (intl) => (declaration) =>
 const newGlobalExpectation = (types, expect, id) =>
   newExpectation(types, `through ${toEDLString(entryPointType)} ${expect}`, id, { declaration: entryPointType })
 
+//Expectation name is encoded to prevent errors when using accent marks: https://github.com/Program-AR/pilas-bloques/issues/1096
 export const newExpectation = (types, expect, id, opts = {}) =>
-  `expectation "${stringify(id, { ...types, ...opts })}": ${expect};`
+  `expectation "${btoa(stringify(id, { ...types, ...opts }))}": ${expect};`
 
 export const multiExpect = (...expectations) => (element) =>
   join(expectations.map(e => e(element)))

--- a/tests/unit/services/mulang-expectations-test.js
+++ b/tests/unit/services/mulang-expectations-test.js
@@ -324,7 +324,7 @@ module('Unit | Service | Mulang | Expectations', function (hooks) {
       const fullId = mulang
         .astCode(rawSequence([]))
         .customExpect(edl)
-        .map(([name]) => parseExpect(name))
+        .map(([name]) => parseExpect(atob(name))) // jshint ignore:line
 
       assert.deepEqual(fullId, expectedIds)
     })


### PR DESCRIPTION
Resolves #1096 

Intenté ver por el lado de mulang qué causa el problema, pero tuve problemas tratando de debbugear localmente (stack y ghcjs ya no se llevan bien :cry:). Para no seguir gastando tiempo en eso, como parche se encodearon con base24 los nombres de los expects antes de mandarlos a mulang (mulang no hace nada con los nombres asi que no debería haber problemas), y después cuando las recibimos como nosotros sí necesitamos los nombres, se decodean.

Se podría a futuro gastarle un poco más de tiempo para ver bien si se puede solucionar por el lado de mulang.

Por alguna razón a jshint no le gusta el `atob` :thinking: 