### PR TITLE
Nuevos comandos no contaba como ejercicio de decomposition

### DIFF
--- a/app/services/challenge-expectations.js
+++ b/app/services/challenge-expectations.js
@@ -141,7 +141,8 @@ export default Service.extend({
   },
 
   hasDecomposition(challenge) {
-    return !!this.allExpectConfigurationsMerged(challenge).decomposition
+    const allExpectConfigurationsMerged = this.allExpectConfigurationsMerged(challenge)
+    return !!(allExpectConfigurationsMerged.decomposition || allExpectConfigurationsMerged.decomposition9)
   },
 
   totalScoreOf(challenge) {


### PR DESCRIPTION
El ejercicio 46: Nuevos comandos no estaba siendo guardado entre los desafios resueltos de decomposition, por ende no contaba para sacar las sugerencias a los 6 desafios resueltos. 
Esto era porque para saber si sumar el desafio o no, se fijaba que tuviera la expectativa `decomposition`, que justamente no tiene (tiene `decomposition9` :cry: ).

Probablemente cambie con el rediseño de las expectativas, pero mientras un (otro) parchesito (más).

Aproveche a fijarme si había algún otro lugar donde se estuviera usando `decomposition` y no `decomposition9` pero estamos bien con el resto.