### PR TITLE
Jshint usa esversion: 11

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -22,7 +22,7 @@
     "unzipit",
     "ProcedsBlockly"
   ],
-  "esversion": 9,
+  "esversion": 11,
   "asi": true,
   "browser": true,
   "boss": true,

--- a/app/services/challenge-expectations.js
+++ b/app/services/challenge-expectations.js
@@ -154,7 +154,7 @@ export default Service.extend({
   },
 
   configIdToMaxScore(id) {
-    return harcodedAllConfigurationsToExpectIds[id] ? harcodedAllConfigurationsToExpectIds[id].length : 0
+    return harcodedAllConfigurationsToExpectIds[id]?.length || 0
   },
 
   expectationsIdsForControlGroup(challenge) {

--- a/app/services/experiments.js
+++ b/app/services/experiments.js
@@ -44,7 +44,7 @@ export default Service.extend({
   },
 
   getExperimentGroupAssigned() {
-    return this.pilasBloquesApi.getUser()?.experimentGroup || this.storage.getExperimentGroup() || this.randomizeAndSaveExperimentGroup() // jshint ignore:line
+    return this.pilasBloquesApi.getUser()?.experimentGroup || this.storage.getExperimentGroup() || this.randomizeAndSaveExperimentGroup()
   },
 
   randomizeAndSaveExperimentGroup() {

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -36,7 +36,7 @@
     "ProcedsBlockly",
     "Response"
   ],
-  "esversion": 9,
+  "esversion": 11,
   "asi": true,
   "node": false,
   "browser": false,


### PR DESCRIPTION
Resolves #1134 

Lo tiro a la branch `unused-expectations` porque ahí está uno de los lugares en donde se podía usar optional chaining (para no olvidarse después)