### PR TITLE
Expectation modal se ve bien al achicar

### DIFF
--- a/app/templates/components/expectation-modal.hbs
+++ b/app/templates/components/expectation-modal.hbs
@@ -1,5 +1,5 @@
 <Modal @title={{t (compute (action textTag "title"))}} @onClose={{onClose}}>
-  <PaperCard class="details-card flex layout-row expectationModal">
+  <PaperCard class="details-card layout-row expectationModal">
       <img class="exercise-cover" alt="{{challenge.titulo}}" src="{{challenge.coverSrc}}">
       <p>{{t (compute (action textTag  "description"))}}</p>
   </PaperCard>


### PR DESCRIPTION
Resolves #1142 

En chrome se ve igual.
![Peek 17-10-2022 15-18](https://user-images.githubusercontent.com/48812037/196253038-fdda8846-0960-4672-bfe8-60c5877dc21d.gif)

Modal con todo bien hecho:
![imagen](https://user-images.githubusercontent.com/48812037/196253563-3a83be25-d497-4f1b-953b-096384af13cb.png)

