### PR TITLE
Reemplazando paper menu

### DIFF
--- a/app/components/language-menu.js
+++ b/app/components/language-menu.js
@@ -5,6 +5,7 @@ import { computed } from '@ember/object';
 export default Component.extend({
 
     intl: service(),
+    menuOpen: false,
     disabledLanguages: [],
     localeCodes: computed("intl", function () {
         return this.get('intl').get('locales').filter(localeCode => !this.disabledLanguages.includes(localeCode))
@@ -17,6 +18,10 @@ export default Component.extend({
     actions: {
         setLocale: function (selectedLocaleCode) {
             this.intl.setSelectedLocale(selectedLocaleCode)
-        }
+        },
+
+        menuToggle: function() {
+            this.set("menuOpen", !this.get('menuOpen')) 
+        },
     }
 });

--- a/app/components/language-menu.js
+++ b/app/components/language-menu.js
@@ -6,6 +6,8 @@ export default Component.extend({
 
     intl: service(),
     disabledLanguages: [],
+    menuOpen: false,
+    
     localeCodes: computed("intl", function () {
         return this.get('intl').get('locales').filter(localeCode => !this.disabledLanguages.includes(localeCode))
     }),

--- a/app/components/language-menu.js
+++ b/app/components/language-menu.js
@@ -5,7 +5,6 @@ import { computed } from '@ember/object';
 export default Component.extend({
 
     intl: service(),
-    menuOpen: false,
     disabledLanguages: [],
     localeCodes: computed("intl", function () {
         return this.get('intl').get('locales').filter(localeCode => !this.disabledLanguages.includes(localeCode))

--- a/app/components/navigation-menu.js
+++ b/app/components/navigation-menu.js
@@ -1,4 +1,9 @@
 import Component from '@ember/component';
 
 export default Component.extend({
+    actions: {
+        menuToggle: function() {
+            this.set("menuOpen", !this.get('menuOpen')) 
+        },
+    }
 });

--- a/app/components/navigation-menu.js
+++ b/app/components/navigation-menu.js
@@ -1,6 +1,8 @@
 import Component from '@ember/component';
 
 export default Component.extend({
+    menuOpen: false,
+    
     actions: {
         menuToggle: function() {
             this.set("menuOpen", !this.get('menuOpen')) 

--- a/app/components/session-button.js
+++ b/app/components/session-button.js
@@ -21,14 +21,13 @@ export default Component.extend({
   },
 
   actions: {
-    changeUser() {
-      this.pilasBloquesApi.logout()
-      this.updateSession()
-      this.set("openLogin", true)
-    },
     logout() {
       this.pilasBloquesApi.logout()
       document.location.reload()
     },
+
+    menuToggle() {
+      this.set("menuOpen", !this.get('menuOpen')) 
+  },
   },
 });

--- a/app/components/session-button.js
+++ b/app/components/session-button.js
@@ -7,7 +7,8 @@ export default Component.extend({
   avatardb: service(),
   wrongLogin: false,
   session: null,
-
+  menuOpen: false,
+  
   randomAvatar: computed("avatardb", function() {
     return this.avatardb.randomAvatar()
   }),

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -535,9 +535,17 @@ md-menu-content > md-menu-item {
   color: inherit;
 }
 
-.paper-card{
+.themed-background{
   background-color: var(--theme-background-color) !important;
+}
+
+.paper-card{
+  @extend .themed-background;
   border-radius: 10px;
+}
+
+.paper-menu ul{
+  @extend .themed-background;
 }
 
 md-card {

--- a/app/templates/components/language-menu.hbs
+++ b/app/templates/components/language-menu.hbs
@@ -2,7 +2,7 @@
     <RPaperIcon @class='language-button' @iconName="language"/>
 </RPaperButton>
 
-<RPaperMenu @triggerId="language-menu" @open={{this.menuOpen}} @onClose={{action "menuToggle"}}>
+<RPaperMenu class="paper-menu" @triggerId="language-menu" @open={{this.menuOpen}} @onClose={{action "menuToggle"}}>
     {{#each localeCodes as |localeCode|}}
         <RPaperMenuItem>
             <RPaperButton @onClick={{action "setLocale" localeCode }}>

--- a/app/templates/components/language-menu.hbs
+++ b/app/templates/components/language-menu.hbs
@@ -1,23 +1,13 @@
-<PaperMenu @offset="5 43" as |menu|>
-    <PaperTooltip>
-        {{t "changeLanguage"}}
-    </PaperTooltip>
+<RPaperButton id="language-menu" class="language-icon" @iconButton={{true}} @onClick={{action "menuToggle"}} >
+    <RPaperIcon @class='language-button' @iconName="language"/>
+</RPaperButton>
 
-    <menu.trigger>
-        <RPaperButton id="language-menu" class="language-icon" @iconButton={{true}}>
-            <RPaperIcon @class='language-button' @iconName="language"/>
-        </RPaperButton>
-    </menu.trigger>
-
-    <menu.content as |content|>
-        {{#each localeCodes as |localeCode|}}
-        <content.menu-item>
+<RPaperMenu @triggerId="language-menu" @open={{this.menuOpen}} @onClose={{action "menuToggle"}}>
+    {{#each localeCodes as |localeCode|}}
+        <RPaperMenuItem>
             <RPaperButton @onClick={{action "setLocale" localeCode }}>
                 <span class="menu-item-typography">{{compute (action languageName) localeCode}}</span>
             </RPaperButton>
-        </content.menu-item>
-        {{/each}}
-
-
-    </menu.content>
-</PaperMenu>
+        </RPaperMenuItem>
+    {{/each}}
+</RPaperMenu>

--- a/app/templates/components/navigation-menu.hbs
+++ b/app/templates/components/navigation-menu.hbs
@@ -1,16 +1,11 @@
-<PaperMenu @offset="5 43" as |menu|>
-    
-    <menu.trigger>
-        <RPaperButton id="navigation-menu" class="md-menu-origin" @iconButton={{true}}>
-            <RPaperIcon @iconName="menu"/>
-        </RPaperButton>
-    </menu.trigger>
-    
-    <menu.content as |content|>
+<RPaperButton id="navigation-menu" class="md-menu-origin" @iconButton={{true}} @onClick={{action "menuToggle"}}>
+    <RPaperIcon @iconName="menu"/>
+</RPaperButton>
 
+<RPaperMenu @triggerId="navigation-menu" @open={{this.menuOpen}} @onClose={{action "menuToggle"}}>
         {{#if this.book}}
             {{!-- Challenge book --}}
-                <content.menu-item>
+                <RPaperMenuItem>
                     <RPaperButton 
                         @disabled={{false}} 
                         @raised={{false}} 
@@ -19,10 +14,10 @@
                         @href={{href-to "libros.verLibro" this.book.id}}>
                         <span class="menu-item-typography">{{this.book.titulo}}</span>
                     </RPaperButton>
-                </content.menu-item>
+                </RPaperMenuItem>
 
                 {{!-- Challenge chapter --}}
-                <content.menu-item>
+                <RPaperMenuItem>
                     <RPaperButton 
                         @disabled={{false}} 
                         @raised={{false}} 
@@ -31,11 +26,11 @@
                         @href={{href-to "libros.verLibro" this.book.id}}>
                         <span class="menu-item-typography">{{this.chapter.titulo}}</span>
                     </RPaperButton>
-                </content.menu-item>
+                </RPaperMenuItem>
 
                 {{!-- Challenge group --}}
                 {{#if this.challenge.grupo.titulo}}
-                    <content.menu-item>
+                    <RPaperMenuItem>
                         <RPaperButton 
                             @disabled={{false}}
                             @raised={{false}}
@@ -44,12 +39,12 @@
                             @href={{href-to "libros.verLibro" this.book.id}}>
                             <span class="menu-item-typography">{{this.group.titulo}}</span>
                         </RPaperButton>
-                    </content.menu-item>
+                    </RPaperMenuItem>
                 {{/if}}
             {{/if}}
             
             {{!-- Challenge title --}}
-            <content.menu-item>
+            <RPaperMenuItem>
                 <RPaperButton 
                     @disabled={{false}}
                     @raised={{false}}
@@ -58,7 +53,5 @@
                     >
                     <span class="menu-item-typography challenge-title">{{this.challenge.titulo}}</span>
                 </RPaperButton>
-            </content.menu-item>
-
-        </menu.content>
-</PaperMenu>
+            </RPaperMenuItem>
+</RPaperMenu>

--- a/app/templates/components/navigation-menu.hbs
+++ b/app/templates/components/navigation-menu.hbs
@@ -2,7 +2,7 @@
     <RPaperIcon @iconName="menu"/>
 </RPaperButton>
 
-<RPaperMenu @triggerId="navigation-menu" @open={{this.menuOpen}} @onClose={{action "menuToggle"}}>
+<RPaperMenu class="paper-menu" @triggerId="navigation-menu" @open={{this.menuOpen}} @onClose={{action "menuToggle"}}>
         {{#if this.book}}
             {{!-- Challenge book --}}
                 <RPaperMenuItem>

--- a/app/templates/components/session-button.hbs
+++ b/app/templates/components/session-button.hbs
@@ -4,7 +4,7 @@
     <RPaperButton @iconButton={{true}} @onClick={{action "menuToggle"}}> {{ this.session.nickName }} </RPaperButton>
   </div>
   
-  <RPaperMenu @triggerId="session-button" @open={{this.menuOpen}} @onClose={{action "menuToggle"}}>
+  <RPaperMenu class="paper-menu" @triggerId="session-button" @open={{this.menuOpen}} @onClose={{action "menuToggle"}}>
       <RPaperMenuItem>
         <Button @onClick={{action "logout"}}> {{t "components.sessionButton.logout"}} </Button>
       </RPaperMenuItem>

--- a/app/templates/components/session-button.hbs
+++ b/app/templates/components/session-button.hbs
@@ -1,19 +1,14 @@
 {{#if this.session}}
-  <PaperMenu @offset="5 43" as |menu|>
-    <menu.trigger class="user-menu">
-      <img class="face" src= {{ this.session.avatarURL }} />
-      <Button> {{ this.session.nickName }} </Button>
-    </menu.trigger>
-    <menu.content as |content|>
-      <content.menu-item>
-        <Button @onClick={{action "changeUser"}}> {{t "components.sessionButton.changeUser"}} </Button>
-      </content.menu-item>
-
-      <content.menu-item>
+  <div id="session-button" class="user-menu">
+    <img class="face" src= {{ this.session.avatarURL }} />
+    <RPaperButton @iconButton={{true}} @onClick={{action "menuToggle"}}> {{ this.session.nickName }} </RPaperButton>
+  </div>
+  
+  <RPaperMenu @triggerId="session-button" @open={{this.menuOpen}} @onClose={{action "menuToggle"}}>
+      <RPaperMenuItem>
         <Button @onClick={{action "logout"}}> {{t "components.sessionButton.logout"}} </Button>
-      </content.menu-item>
-    </menu.content>
-  </PaperMenu>
+      </RPaperMenuItem>
+  </RPaperMenu>
   <PersonalSurvey />
 {{else}}
   <img class="face gray" src={{ this.randomAvatar }} />


### PR DESCRIPTION
Resolves [#1213](https://github.com/Program-AR/pilas-bloques/issues/1213)

❗❗❗ Cosa maso importante a considerar antes de leer mis comentarios: Al abrir uno de estos menus no podes clickear en nada que no sean los items del menu. Haciendo click una vez fuera del menu el menu desaparece y podes volver a clickear:

![kobeni](https://user-images.githubusercontent.com/37090248/211916218-d5769033-fa55-4e41-ae01-c54d2b418e63.gif)
La unica vez que hago click en ese gif es cuando desaparece el menu, el resto del tiempo estoy solo pasando el mouse mostrando cuando aparece la manito de click.
Esto pasa porque al abrir un menu se pone un div que cubre toda la pantalla. No me parece que este mal, pero lo menciono porque es relevante para algunos comentarios del PR.

![image](https://user-images.githubusercontent.com/37090248/211901700-b78e9452-8772-4fbe-9062-04942c5e57a8.png)
![image](https://user-images.githubusercontent.com/37090248/211901796-cd482556-e7d7-4ea6-a4c5-3155c62fae9b.png)
![image](https://user-images.githubusercontent.com/37090248/211901897-e5ddd2f6-021c-4456-8e6a-ff5cb15c510e.png)
