### PR TITLE
chapter numbers and link removed

### DIFF
--- a/app/templates/libros/ver-libro.hbs
+++ b/app/templates/libros/ver-libro.hbs
@@ -4,9 +4,6 @@
 
   <h1> {{t "templates.libros.ver-libro.challengesOf"}} {{this.model.titulo}}</h1>
 
-  <p><Link @href={{href-to "libros"}} @openOnNewTab={{false}}><FaIcon @icon="chevron-left"/> {{t "templates.libros.ver-libro.backBooksList"}}</Link></p>
-
-
   {{#each this.model.capitulos as |capitulo|}}
     <div data-test-book-view-chapter>
 

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -792,11 +792,11 @@ model:
       description: Tecnópolis Challenges
   chapters:
     Capítulo 3:
-      title: 'Chapter 3: Programming in your computer'
+      title: 'Chapter: Programming in your computer'
     Capítulo 4:
-      title: 'Chapter 4: Repetition'
+      title: 'Chapter: Repetition'
     Capítulo 5:
-      title: 'Chapter 5: Conditional alternative'
+      title: 'Chapter: Conditional alternative'
     'Autómatas, comandos, procedimientos y repetición':
       title: 'Automatons, commands, procedures, and repetition'
     Alternativa condicional:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -792,11 +792,11 @@ model:
       description: Tecnópolis Challenges
   chapters:
     Capítulo 3:
-      title: 'Chapter: Programming in your computer'
+      title: 'Programming in your computer'
     Capítulo 4:
-      title: 'Chapter: Repetition'
+      title: 'Repetition'
     Capítulo 5:
-      title: 'Chapter: Conditional alternative'
+      title: 'Conditional alternative'
     'Autómatas, comandos, procedimientos y repetición':
       title: 'Automatons, commands, procedures, and repetition'
     Alternativa condicional:

--- a/translations/es-ar.yaml
+++ b/translations/es-ar.yaml
@@ -798,11 +798,11 @@ model:
       description: Desafios de Tecnópolis 2021
   chapters:
     Capítulo 3:
-      title: 'Capítulo: Programando en la computadora'
+      title: 'Programando en la computadora'
     Capítulo 4:
-      title: 'Capítulo: Repetición'
+      title: 'Repetición'
     Capítulo 5:
-      title: 'Capítulo: Alternativa condicional'
+      title: 'Alternativa condicional'
     'Autómatas, comandos, procedimientos y repetición':
       title: 'Autómatas, comandos, procedimientos y repetición'
     Alternativa condicional:

--- a/translations/es-ar.yaml
+++ b/translations/es-ar.yaml
@@ -798,11 +798,11 @@ model:
       description: Desafios de Tecnópolis 2021
   chapters:
     Capítulo 3:
-      title: 'Capítulo 3: Programando en la computadora'
+      title: 'Capítulo: Programando en la computadora'
     Capítulo 4:
-      title: 'Capítulo 4: Repetición'
+      title: 'Capítulo: Repetición'
     Capítulo 5:
-      title: 'Capítulo 5: Alternativa condicional'
+      title: 'Capítulo: Alternativa condicional'
     'Autómatas, comandos, procedimientos y repetición':
       title: 'Autómatas, comandos, procedimientos y repetición'
     Alternativa condicional:

--- a/translations/pt-br.yaml
+++ b/translations/pt-br.yaml
@@ -780,11 +780,11 @@ model:
       description: Desafios de Tecnopolis 2021
   chapters:
     Capítulo 3:
-      title: 'Capítulo 3: Programando no computador'
+      title: 'Capítulo: Programando no computador'
     Capítulo 4:
-      title: 'Capítulo 4: Repetição'
+      title: 'Capítulo: Repetição'
     Capítulo 5:
-      title: 'Capítulo 5: Alternativa condicional'
+      title: 'Capítulo: Alternativa condicional'
     Autómatas, comandos, procedimientos y repetición:
       title: Autômatos, comandos, procedimentos e repetição
     Alternativa condicional:

--- a/translations/pt-br.yaml
+++ b/translations/pt-br.yaml
@@ -780,11 +780,11 @@ model:
       description: Desafios de Tecnopolis 2021
   chapters:
     Capítulo 3:
-      title: 'Capítulo: Programando no computador'
+      title: 'Programando no computador'
     Capítulo 4:
-      title: 'Capítulo: Repetição'
+      title: 'Repetição'
     Capítulo 5:
-      title: 'Capítulo: Alternativa condicional'
+      title: 'Alternativa condicional'
     Autómatas, comandos, procedimientos y repetición:
       title: Autômatos, comandos, procedimentos e repetição
     Alternativa condicional:

--- a/translations/templates/libros/en-us.yaml
+++ b/translations/templates/libros/en-us.yaml
@@ -8,5 +8,4 @@ index:
     part2: ' to learn more about this tool and its developers.'
 ver-libro:
   challengesOf: Challenges of
-  backBooksList: Back to books list
   withoutChallenges: 'Sorry, there are no challenges for this manual yet.'

--- a/translations/templates/libros/es-ar.yaml
+++ b/translations/templates/libros/es-ar.yaml
@@ -8,5 +8,4 @@ index:
     part2: ' para conocer más en detalle de qué se trata esta herramienta y quién la desarrolló.'
 ver-libro:
   challengesOf: Desafíos de
-  backBooksList: Volver a la lista de libros
   withoutChallenges: 'Lo siento, no hay desafíos para este manual aún.'

--- a/translations/templates/libros/pt-br.yaml
+++ b/translations/templates/libros/pt-br.yaml
@@ -8,5 +8,4 @@ index:
     part2: ' para saber mais sobre o que é esta ferramenta e quem a desenvolveu.'
 ver-libro:
   challengesOf: Desafios de
-  backBooksList: Voltar para a lista de livros
   withoutChallenges: Desculpe, não há desafios para este manual ainda.


### PR DESCRIPTION
Resolves issue #1286 

Se quitaron los numeros y el link a la lista de libros.

![image](https://user-images.githubusercontent.com/91342656/231846291-125fc073-af57-4b8e-bba9-89baf4a1cb7c.png)

Ahora, no convendria quitar también la palabra CAPITULO: ? 

![image](https://user-images.githubusercontent.com/91342656/231846578-67319f70-4f91-46d9-95f9-dbf9faac909e.png)

porque en el segundo ciclo, no dice la palabra CAPITULO sino que directamente está el titulo.

![image](https://user-images.githubusercontent.com/91342656/231846703-fac8a3cc-af1c-4357-95ba-e6d3bc86262b.png)
