### PR TITLE
Chrome in testem

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -2,8 +2,23 @@
 module.exports = {
   test_page: 'tests/index.html?hidepassed&nocontainer',
   disable_watching: true,
-  launch_in_ci: ['Firefox'],
-  launch_in_dev: ['Firefox']
-};
+  launch_in_ci: [
+    'Chrome'
+  ],
+  launch_in_dev: [
+    'Chrome'
+  ],
+  browser_args: {
+    Chrome: {
+      mode: 'ci',
+      args: [
+        '--disable-gpu',
+        '--headless',
+        '--remote-debugging-port=0',
+        '--window-size=1440,900'
+      ]
+    }
+  }
+};  
 
 


### PR DESCRIPTION
Por sugerencia de @asanzo vuelvo a cambiar testem para usar Chrome en lugar de Firefox como estaba en la branch develop antes de las pruebas.
Consultamos a @tfloxolodeiro sobre el original de https://github.com/Program-AR/pilas-bloques/commit/1f63e964d12d7c80cb2a76328102214a3054df61 por si recuerda el motivo de usar FF
