### PR TITLE
Npm install no tarda 14min en el CI (esta vez de verdad)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28862,7 +28862,7 @@
         "abbrev": "1.0.x",
         "async": "0.2.x",
         "escodegen": "1.2.x",
-        "esprima": "git://github.com/ariya/esprima.git#harmony",
+        "esprima": "https://github.com/ariya/esprima.git#harmony",
         "fileset": "0.1.x",
         "handlebars": "1.3.x",
         "js-yaml": "3.x",
@@ -28900,8 +28900,8 @@
           }
         },
         "esprima": {
-          "version": "git://github.com/ariya/esprima.git#a65a3eb93b9a5dce9a1184ca2d1bd0b184c6b8fd",
-          "from": "git://github.com/ariya/esprima.git#harmony",
+          "version": "https://github.com/ariya/esprima.git#a65a3eb93b9a5dce9a1184ca2d1bd0b184c6b8fd",
+          "from": "https://github.com/ariya/esprima.git#harmony",
           "optional": true
         },
         "estraverse": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "pack:osx": "bash ./scripts/package.sh -osx",
     "pack:win32": "bash ./scripts/package.sh -win32",
     "pack:html": "bash ./scripts/package.sh -html",
-    "preinstall": "git config url.https://github.com/.insteadOf git://github.com/",
+    "preinstall": "git config url.https://github.com/.insteadOf git://github.com/ && git config --list",
     "postinstall": "node ./scripts/remove-mulang-require.js && node ./scripts/change-sass-division.js && node ./scripts/change-pilas-versions.js && node ./scripts/tryInvoke-deprecation-fix.js",
     "clean": "rm -rf node_modules dist dist_prod",
     "release": "release-it --only-version"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "pack:osx": "bash ./scripts/package.sh -osx",
     "pack:win32": "bash ./scripts/package.sh -win32",
     "pack:html": "bash ./scripts/package.sh -html",
-    "preinstall": "git config url.\"https://github.com/\".insteadOf git://github.com/ && git config --list",
     "postinstall": "node ./scripts/remove-mulang-require.js && node ./scripts/change-sass-division.js && node ./scripts/change-pilas-versions.js && node ./scripts/tryInvoke-deprecation-fix.js",
     "clean": "rm -rf node_modules dist dist_prod",
     "release": "release-it --only-version"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "pack:osx": "bash ./scripts/package.sh -osx",
     "pack:win32": "bash ./scripts/package.sh -win32",
     "pack:html": "bash ./scripts/package.sh -html",
-    "preinstall": "git config url.https://github.com/.insteadOf git://github.com/ && git config --list",
+    "preinstall": "git config url.\"https://github.com/\".insteadOf git://github.com/ && git config --list",
     "postinstall": "node ./scripts/remove-mulang-require.js && node ./scripts/change-sass-division.js && node ./scripts/change-pilas-versions.js && node ./scripts/tryInvoke-deprecation-fix.js",
     "clean": "rm -rf node_modules dist dist_prod",
     "release": "release-it --only-version"


### PR DESCRIPTION
Por alguna razón no estaba funcionando en el ci el trucazo de la línea de git config para reemplazar el url:

![imagen](https://user-images.githubusercontent.com/48812037/236018967-4ad625df-7ae9-4aa7-b828-ef596fc3ffcd.png)

Asi que directamente cambié en el package-lock la dependencia que usaba el deprecado `git://` por `https://` y anduvo localmente y en el ci, ahora debería tardar aprox 1min y medio, adjunto pruebas :D

![imagen](https://user-images.githubusercontent.com/48812037/236018794-0902f98b-c38c-4180-9b30-61dda29e8821.png)
