### PR TITLE
Botón desactivar warnings

### DIFF
--- a/app/components/challenge-workspace-buttons.js
+++ b/app/components/challenge-workspace-buttons.js
@@ -11,7 +11,6 @@ export default Component.extend({
   xml: null,
   store: service(),
   deleteDialogIsOpen: false,
-  warningsDisabled: true,
   platform: service(),
   intl: service(),
 
@@ -85,14 +84,22 @@ export default Component.extend({
     input.value = null;
   },
 
+  changeWarningVisibility(visible) {
+    changeWarningVisibility(visible)
+    this.set('warningsVisible', visible)
+  },
+
   actions: {
     abrirSolucion() {
       this.fileInput().click();
     },
+    
+    enableWarnings() {
+      this.changeWarningVisibility(true)
+    },
 
-    changeWarningVisibility() {
-      changeWarningVisibility(!this.get('warningsDisabled'))
-      this.set('warningsDisabled', !this.get('warningsDisabled'))
+    disableWarnings() {
+      this.changeWarningVisibility(false)
     },
 
     guardarSolucion() {

--- a/app/components/challenge-workspace-buttons.js
+++ b/app/components/challenge-workspace-buttons.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
+import { changeWarningVisibility } from '../utils/blocks';
 
 const VERSION_DEL_FORMATO_DE_ARCHIVO = 2;
 
@@ -10,6 +11,7 @@ export default Component.extend({
   xml: null,
   store: service(),
   deleteDialogIsOpen: false,
+  warningsDisabled: true,
   platform: service(),
   intl: service(),
 
@@ -86,6 +88,11 @@ export default Component.extend({
   actions: {
     abrirSolucion() {
       this.fileInput().click();
+    },
+
+    changeWarningVisibility() {
+      changeWarningVisibility(!this.get('warningsDisabled'))
+      this.set('warningsDisabled', !this.get('warningsDisabled'))
     },
 
     guardarSolucion() {

--- a/app/components/pilas-blockly.js
+++ b/app/components/pilas-blockly.js
@@ -21,6 +21,7 @@ export default Component.extend({
   codigoJavascript: "", // Se carga como parametro
   codigo: null,
   challenge: null,
+  warningsVisible: true,
 
   highlighter: service(),
   availableBlocksValidator: service(),
@@ -436,7 +437,7 @@ export default Component.extend({
       .filter(condition)
       .forEach(({ declaration, description }, i) => {
         getBlocks(declaration)
-          .forEach(block => addFeedback(block, description.asSuggestion, -i))
+          .forEach(block => addFeedback(block, description.asSuggestion, -i, this.get('warningsVisible')))
       })
   },
 

--- a/app/styles/challenge-workspace-buttons.scss
+++ b/app/styles/challenge-workspace-buttons.scss
@@ -13,3 +13,17 @@
 .workspace-buttons .md-button.md-fab.md-mini:focus {
     background-color: var(--theme-button-hover-background-color);
 }
+
+#warnings-button .md-button{
+    width: 100%;
+    display: flex;
+    text-transform: none;
+    border-radius: 20px;
+    margin: 4px;
+    color: var(--theme-font-color);
+}
+
+#warnings-button{
+    margin-top: 3px;
+    margin-right: 8px;
+}

--- a/app/templates/components/challenge-workspace-buttons.hbs
+++ b/app/templates/components/challenge-workspace-buttons.hbs
@@ -2,7 +2,7 @@
     <span class="flex"></span>
     <input type='file' id="cargarActividadInput" accept=".spbq" class="hidden" />
     <a id="placeholder" class="hidden">..</a>
-    <Button @tooltip={{if this.warningsDisabled (t "components.challengeWorkspaceButtons.warnings.disable") (t "components.challengeWorkspaceButtons.warnings.enable") }} @isMini={{true}} @isFab={{true}} @isRaised={{true}} @onClick={{action "changeWarningVisibility"}}>{{paper-icon (if this.warningsDisabled "speaker_notes_off" "speaker_notes")}}</Button>
+    <Button @tooltip={{if this.warningsVisible (t "components.challengeWorkspaceButtons.warnings.disable") (t "components.challengeWorkspaceButtons.warnings.enable")}} @isMini={{true}} @isFab={{true}} @isRaised={{true}} @onClick={{action (if this.warningsVisible "disableWarnings" "enableWarnings")}}>{{paper-icon (if this.warningsVisible "speaker_notes_off" "speaker_notes")}}</Button>
     <Button @tooltip={{t "components.challengeWorkspaceButtons.open" }} @isMini={{true}} @isFab={{true}} @isRaised={{true}} @onClick={{action "abrirSolucion"}}>{{paper-icon "folder"}}</Button>
     <Button @tooltip={{t "components.challengeWorkspaceButtons.save"}} @isMini={{true}} @isFab={{true}} @isRaised={{true}} @onClick={{action "guardarSolucion"}}>{{paper-icon "save"}}</Button>
     <Button @tooltip={{t "components.challengeWorkspaceButtons.delete"}} @isMini={{true}} @isFab={{true}} @isRaised={{true}} @onClick={{action (mut this.deleteDialogIsOpen) true}}>{{paper-icon "delete"}}</Button>

--- a/app/templates/components/challenge-workspace-buttons.hbs
+++ b/app/templates/components/challenge-workspace-buttons.hbs
@@ -2,7 +2,7 @@
     <span class="flex"></span>
     <input type='file' id="cargarActividadInput" accept=".spbq" class="hidden" />
     <a id="placeholder" class="hidden">..</a>
-    <Button id="warnings-button" @tooltip={{if this.warningsVisible (t "components.challengeWorkspaceButtons.warnings.disable") (t "components.challengeWorkspaceButtons.warnings.enable")}} @isMini={{true}} @isFab={{true}} @isRaised={{true}} @onClick={{action (if this.warningsVisible "disableWarnings" "enableWarnings")}}>{{t "components.challengeWorkspaceButtons.warnings.suggestions"}} {{paper-icon (if this.warningsVisible "speaker_notes_off" "speaker_notes")}}</Button>
+    <Button id="warnings-button" @tooltip={{if this.warningsVisible (t "components.challengeWorkspaceButtons.warnings.disable") (t "components.challengeWorkspaceButtons.warnings.enable")}} @isMini={{true}} @isFab={{true}} @isRaised={{true}} @onClick={{action (if this.warningsVisible "disableWarnings" "enableWarnings")}}>{{paper-icon (if this.warningsVisible "speaker_notes_off" "speaker_notes")}} {{t "components.challengeWorkspaceButtons.warnings.suggestions"}}</Button>
     <Button @tooltip={{t "components.challengeWorkspaceButtons.open" }} @isMini={{true}} @isFab={{true}} @isRaised={{true}} @onClick={{action "abrirSolucion"}}>{{paper-icon "folder"}}</Button>
     <Button @tooltip={{t "components.challengeWorkspaceButtons.save"}} @isMini={{true}} @isFab={{true}} @isRaised={{true}} @onClick={{action "guardarSolucion"}}>{{paper-icon "save"}}</Button>
     <Button @tooltip={{t "components.challengeWorkspaceButtons.delete"}} @isMini={{true}} @isFab={{true}} @isRaised={{true}} @onClick={{action (mut this.deleteDialogIsOpen) true}}>{{paper-icon "delete"}}</Button>

--- a/app/templates/components/challenge-workspace-buttons.hbs
+++ b/app/templates/components/challenge-workspace-buttons.hbs
@@ -2,7 +2,7 @@
     <span class="flex"></span>
     <input type='file' id="cargarActividadInput" accept=".spbq" class="hidden" />
     <a id="placeholder" class="hidden">..</a>
-    <Button @tooltip={{if this.warningsVisible (t "components.challengeWorkspaceButtons.warnings.disable") (t "components.challengeWorkspaceButtons.warnings.enable")}} @isMini={{true}} @isFab={{true}} @isRaised={{true}} @onClick={{action (if this.warningsVisible "disableWarnings" "enableWarnings")}}>{{paper-icon (if this.warningsVisible "speaker_notes_off" "speaker_notes")}}</Button>
+    <Button id="warnings-button" @tooltip={{if this.warningsVisible (t "components.challengeWorkspaceButtons.warnings.disable") (t "components.challengeWorkspaceButtons.warnings.enable")}} @isMini={{true}} @isFab={{true}} @isRaised={{true}} @onClick={{action (if this.warningsVisible "disableWarnings" "enableWarnings")}}>{{t "components.challengeWorkspaceButtons.warnings.suggestions"}} {{paper-icon (if this.warningsVisible "speaker_notes_off" "speaker_notes")}}</Button>
     <Button @tooltip={{t "components.challengeWorkspaceButtons.open" }} @isMini={{true}} @isFab={{true}} @isRaised={{true}} @onClick={{action "abrirSolucion"}}>{{paper-icon "folder"}}</Button>
     <Button @tooltip={{t "components.challengeWorkspaceButtons.save"}} @isMini={{true}} @isFab={{true}} @isRaised={{true}} @onClick={{action "guardarSolucion"}}>{{paper-icon "save"}}</Button>
     <Button @tooltip={{t "components.challengeWorkspaceButtons.delete"}} @isMini={{true}} @isFab={{true}} @isRaised={{true}} @onClick={{action (mut this.deleteDialogIsOpen) true}}>{{paper-icon "delete"}}</Button>

--- a/app/templates/components/challenge-workspace-buttons.hbs
+++ b/app/templates/components/challenge-workspace-buttons.hbs
@@ -2,6 +2,7 @@
     <span class="flex"></span>
     <input type='file' id="cargarActividadInput" accept=".spbq" class="hidden" />
     <a id="placeholder" class="hidden">..</a>
+    <Button @tooltip={{if this.warningsDisabled (t "components.challengeWorkspaceButtons.warnings.disable") (t "components.challengeWorkspaceButtons.warnings.enable") }} @isMini={{true}} @isFab={{true}} @isRaised={{true}} @onClick={{action "changeWarningVisibility"}}>{{paper-icon (if this.warningsDisabled "speaker_notes_off" "speaker_notes")}}</Button>
     <Button @tooltip={{t "components.challengeWorkspaceButtons.open" }} @isMini={{true}} @isFab={{true}} @isRaised={{true}} @onClick={{action "abrirSolucion"}}>{{paper-icon "folder"}}</Button>
     <Button @tooltip={{t "components.challengeWorkspaceButtons.save"}} @isMini={{true}} @isFab={{true}} @isRaised={{true}} @onClick={{action "guardarSolucion"}}>{{paper-icon "save"}}</Button>
     <Button @tooltip={{t "components.challengeWorkspaceButtons.delete"}} @isMini={{true}} @isFab={{true}} @isRaised={{true}} @onClick={{action (mut this.deleteDialogIsOpen) true}}>{{paper-icon "delete"}}</Button>

--- a/app/templates/components/pilas-blockly.hbs
+++ b/app/templates/components/pilas-blockly.hbs
@@ -22,6 +22,7 @@
       <ChallengeWorkspaceButtons 
         @actividad={{this.challenge}} 
         @shouldUseFloatingMode={{this.shouldUseFloatingMode}} 
+        @warningsVisible={{this.warningsVisible}}
         @changeScreenMode={{this.changeScreenMode}} 
         @xml={{this.codigoActualEnFormatoXML}}
         @setWorkspace={{action "setWorkspace"}}

--- a/app/utils/blocks.js
+++ b/app/utils/blocks.js
@@ -190,6 +190,10 @@ export function addError(block, message, index) {
   addWarningToBlock(block, '★', message, index, 'red')
 }
 
+export function changeWarningVisibility(visible) {
+  Blockly.getMainWorkspace().getAllBlocks().forEach(b => b.warning && b.warning.setVisible(visible))
+}
+
 function textWasChanged(fieldName, event) {
   return event.element === 'field' && event.name === fieldName && (event.oldValue !== event.newValue)
 }

--- a/app/utils/blocks.js
+++ b/app/utils/blocks.js
@@ -175,19 +175,20 @@ const setWarningBubbleColour = (block, colour) => {
   block.warning.setVisible = (visible) => { boundedSetVisible(visible); if (visible) block.warning.bubble_.setColour(colour) }
 }
 
-const addWarningToBlock = (block, itemChar, message, index, bubbleColour) => {
+const addWarningToBlock = (block, itemChar, message, index, bubbleColour, visible = true) => {
   const text = `${itemChar} ${lineWrap(message)}`
   block.setWarningText(text, index)
   setWarningBubbleColour(block, bubbleColour)
-  block.warning.setVisible(true)
+  block.warning.setVisible(visible)
 }
 
-export function addWarning(block, message, index) {
-  addWarningToBlock(block, '☆', message, index, 'yellow')
+export function addWarning(block, message, index, visible) {
+  addWarningToBlock(block, '☆', message, index, 'yellow', visible)
 }
 
-export function addError(block, message, index) {
-  addWarningToBlock(block, '★', message, index, 'red')
+export function addError(block, message, index, visible) {
+  console.log(visible)
+  addWarningToBlock(block, '★', message, index, 'red', visible)
 }
 
 export function changeWarningVisibility(visible) {

--- a/translations/components/en-us.yaml
+++ b/translations/components/en-us.yaml
@@ -59,8 +59,9 @@ challengeWorkspaceButtons:
   wrongActivity: 'Be careful! The file indicates that it is from another challenge ({activity}). It will be loaded anyways, but it could fail.'
   oldVersion: 'Be careful! The file indicates that it is from an older version. It will be loaded anyways, but we suggest that you solve the challenge again and save the solution in a new file.'
   warnings:
-    disable: 'Disable warnings'
-    enable: 'Enable warnings'
+    disable: 'Disable suggestions'
+    enable: 'Enable suggestions'
+    suggestions: 'Suggestions'
 footer:
   version: 'Version:'
   problem: Any problem with this exercise?

--- a/translations/components/en-us.yaml
+++ b/translations/components/en-us.yaml
@@ -58,6 +58,9 @@ challengeWorkspaceButtons:
   notASolution: This file does not have a Pilas Bloques solution.
   wrongActivity: 'Be careful! The file indicates that it is from another challenge ({activity}). It will be loaded anyways, but it could fail.'
   oldVersion: 'Be careful! The file indicates that it is from an older version. It will be loaded anyways, but we suggest that you solve the challenge again and save the solution in a new file.'
+  warnings:
+    disable: 'Disable warnings'
+    enable: 'Enable warnings'
 footer:
   version: 'Version:'
   problem: Any problem with this exercise?

--- a/translations/components/es-ar.yaml
+++ b/translations/components/es-ar.yaml
@@ -59,8 +59,9 @@ challengeWorkspaceButtons:
   wrongActivity: '¡Cuidado! El archivo indica que es para otra actividad ({activity}). Se cargará de todas formas, pero puede fallar.'
   oldVersion: '¡Cuidado! El archivo indica que es de una versión anterior. Se cargará de todas formas, pero te sugerimos que resuelvas nuevamente el ejercicio y guardes un nuevo archivo.'
   warnings:
-    disable: 'Desactivar advertencias'
-    enable: 'Activar advertencias'
+    disable: 'Desactivar sugerencias'
+    enable: 'Activar sugerencias'
+    suggestions: 'Sugerencias'
 footer:
   version: 'Versión:'
   problem: ¿Algún problema con este ejercicio?

--- a/translations/components/es-ar.yaml
+++ b/translations/components/es-ar.yaml
@@ -58,6 +58,9 @@ challengeWorkspaceButtons:
   notASolution: Este archivo no tiene una solución de Pilas Bloques.
   wrongActivity: '¡Cuidado! El archivo indica que es para otra actividad ({activity}). Se cargará de todas formas, pero puede fallar.'
   oldVersion: '¡Cuidado! El archivo indica que es de una versión anterior. Se cargará de todas formas, pero te sugerimos que resuelvas nuevamente el ejercicio y guardes un nuevo archivo.'
+  warnings:
+    disable: 'Desactivar advertencias'
+    enable: 'Activar advertencias'
 footer:
   version: 'Versión:'
   problem: ¿Algún problema con este ejercicio?

--- a/translations/components/pt-br.yaml
+++ b/translations/components/pt-br.yaml
@@ -58,6 +58,9 @@ challengeWorkspaceButtons:
   notASolution: Este arquivo não tem uma solução da Pilas Blocos.
   wrongActivity: Cuidado! O arquivo indica que é para outra atividade ({activity}). Será carregado de cualquer forma, mas pode falhar.
   oldVersion: Cuidado! O arquivo indica que é de uma versão anterior. Será carregado de qualquer forma, mas sugerimos que resolva novamente o exercício e guarde um novo arquivo.
+  warnings:
+    disable: 'Desativar avisos'
+    enable: 'Ativar avisos'
 footer:
   version: 'Versão:'
   problem: Problemas com este exercício?

--- a/translations/components/pt-br.yaml
+++ b/translations/components/pt-br.yaml
@@ -59,8 +59,9 @@ challengeWorkspaceButtons:
   wrongActivity: Cuidado! O arquivo indica que é para outra atividade ({activity}). Será carregado de cualquer forma, mas pode falhar.
   oldVersion: Cuidado! O arquivo indica que é de uma versão anterior. Será carregado de qualquer forma, mas sugerimos que resolva novamente o exercício e guarde um novo arquivo.
   warnings:
-    disable: 'Desativar avisos'
-    enable: 'Ativar avisos'
+    disable: 'Desativar sugestões'
+    enable: 'Ativar sugestões'
+    suggestions: 'Sugestões'
 footer:
   version: 'Versão:'
   problem: Problemas com este exercício?


### PR DESCRIPTION
Resolves lo que charlamos (parte)

Habíamos hablado de cambiar los colores (ahora todos los iconitos son azules), me metí con eso y se me extendió demasiado, me parece que se puede resolver en issues más chicos. 

![Peek 2023-09-04 23-05](https://github.com/Program-AR/pilas-bloques/assets/48812037/d0614d90-9211-4781-85c4-ebf022360135)

El icono de warning existe en material design, pero no existe la versión tachada (warning_off), asi que para no complicar la existencia demasiado fui por usar este ícono que me parece que da a entender que es para sacar y poner las burbujas:

![imagen](https://github.com/Program-AR/pilas-bloques/assets/48812037/ef9db669-2243-4a1b-b34c-2208e6465bfd)
![imagen](https://github.com/Program-AR/pilas-bloques/assets/48812037/cdf234eb-a1e8-47f0-888b-111b84d5c100)

Se puede buscar otros [por acá si no](https://fonts.google.com/icons?icon.set=Material+Icons).

Sobre lo que queda: los errores se agregan desde varios lugares, no solo desde `pilas-blockly`, lo cual dificulta un poco mantener el estado de si está o no clickeado. Por ahora dejé en default true que se muestren cuando no se agregan desde pilas-blockly (al ejecutar). 
Sobre los colores, logré cambiarlos overrideando [drawIcon_](https://groups.google.com/g/blockly/c/745fpNWOwlM), pero no logré que quede bien, a veces me cambiaba el rojo por el amarillo en los warnings y error :eyes:, a veces seguía en azul. Le debo estar pifiando en el lugar en donde configurarlo. Me parece que estas dos cositas se pueden hacer juntas en otra iteración y no prolongar más esto.