### PR TITLE
Volver a usar Electron installer debian oficial

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pilasbloques",
-  "version": "1.14.5",
+  "version": "1.14.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15845,8 +15845,9 @@
       }
     },
     "electron-installer-debian": {
-      "version": "git+https://github.com/Program-AR/electron-installer-debian.git#6d69b6eb0d553e95b94a45ee6a6a90f934f00eb2",
-      "from": "git+https://github.com/Program-AR/electron-installer-debian.git",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/electron-installer-debian/-/electron-installer-debian-3.2.0.tgz",
+      "integrity": "sha512-58ZrlJ1HQY80VucsEIG9tQ//HrTlG6sfofA3nRGr6TmkX661uJyu4cMPPh6kXW+aHdq/7+q25KyQhDrXvRL7jw==",
       "optional": true,
       "requires": {
         "@malept/cross-spawn-promise": "^1.0.0",
@@ -32823,9 +32824,9 @@
       }
     },
     "pilas-bloques-exercises": {
-      "version": "1.2.25",
-      "resolved": "https://registry.npmjs.org/pilas-bloques-exercises/-/pilas-bloques-exercises-1.2.25.tgz",
-      "integrity": "sha512-MjT30N+5e3RXDtT8Tv/zQrCRUsEMm+sVXpQIO34Kj9P1G8EcxDxxNKihMz+Ws6J+PWS8DelSyDdnRmg5eJtjNA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pilas-bloques-exercises/-/pilas-bloques-exercises-1.3.1.tgz",
+      "integrity": "sha512-sYUz1n+xUrBw6u2+/z6vFqsg6IJl31KGAwI4lsdX+okiOYWpJxxQQgzBvOfog8DrwBjdeRc5l4asjrCvG1EJFw==",
       "requires": {
         "pilasweb": "^0.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "shelljs": "^0.8.5"
   },
   "optionalDependencies": {
-    "electron-installer-debian": "git+https://github.com/Program-AR/electron-installer-debian.git"
+    "electron-installer-debian": "^3.2.0"
   },
   "main": "electron.js",
   "ember": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "Pilas Bloques",
   "genericName": "Programacion con bloques",
   "description": "Una herramienta para aprender a programar utilizando bloques",
-  "version": "1.14.5",
+  "version": "1.14.6",
   "homepage": "http://pilasbloques.program.ar",
   "author": {
     "name": "Program.AR",

--- a/public/pilas.html
+++ b/public/pilas.html
@@ -22,7 +22,7 @@
 
 <head>
   <script src="libs/pilasweb.js?v=0.5.0"></script>
-  <script src="libs/pilas-bloques-exercises.js?v=1.2.25"></script>
+  <script src="libs/pilas-bloques-exercises.js?v=1.3.1"></script>
 </head>
 
 </html>


### PR DESCRIPTION
Resolves https://github.com/Program-AR/pilas-bloques/issues/1419

![image](https://github.com/Program-AR/pilas-bloques/assets/91342656/ac756ab1-6275-4b07-80fd-edb1823db8f9)

Instalacion del .deb en Huayra, funciona perfectamente, tanto la instalacion como pilas bloques

