### PR TITLE
Hack para highlight sensores. Incompleto

### DIFF
--- a/app/services/blocks-gallery.js
+++ b/app/services/blocks-gallery.js
@@ -1742,7 +1742,10 @@ export default Service.extend({
     Blockly.MyLanguage.Hasta = function (block) {
       var condition = Blockly.MyLanguage.valueToCode(block, 'condition', Blockly.MyLanguage.ORDER_ASSIGNMENT) || 'false';
       var contenido = Blockly.MyLanguage.statementToCode(block, 'block');
-      return `while (!${condition}) {
+
+      const highlightCondition = `highlightBlock(${JSON.stringify(block.getInputTargetBlock("condition").id)})`
+
+      return `while (${highlightCondition}, !${condition}) {
         ${contenido}
       }`;
     };

--- a/app/services/highlighter.js
+++ b/app/services/highlighter.js
@@ -18,6 +18,7 @@ export default Service.extend({
             console.warn(`Couldn't highlight block id: ${blockId}`);
             return;
         }
+
         this._removeLastBlockIfEndOfModule();
         this._removePreviousBlockIfContinue(block);
         this._updateHighlight();
@@ -27,6 +28,8 @@ export default Service.extend({
         }
 
         this._updateHighlight();
+
+        if (block.categoryId == "sensors") { alert("espera") } //cambiar esto por un sleep. Es lo que hace que se espere y se vea el highlight
     },
 
     clear() {


### PR DESCRIPTION
Related Program-AR/pilas-bloques-app#227
Resuelto con @PalumboN 

Este PR hace 2 cosas:

1) agrega highlight al sensor de un "repetir hasta"
2) frena (con un alert :laughing:) cada vez que se usa un sensor

Falta:

- [ ] Deshackear el 1) para que sea para cualquier sensor.
- [ ] Deshackear el 2) para poner un sleep, que rápidamente no encontramos cómo hacerlo en Ember.