### PR TITLE
Test desafios con parametros

### DIFF
--- a/app/services/highlighter.js
+++ b/app/services/highlighter.js
@@ -133,7 +133,7 @@ export default Service.extend({
     },
 
     _hasCallOnStack(procedureBlock) {
-        return this._procedureCalls().some(b => getProcedureBlock(b).id === procedureBlock.id)
+        return this._procedureCalls().some(b => getProcedureBlock(b)?.id === procedureBlock?.id)
     },
 
     _workspace() {

--- a/tests/integration/desafios/segundoCiclo/Chuy/InfinitosTrofeos-test.js
+++ b/tests/integration/desafios/segundoCiclo/Chuy/InfinitosTrofeos-test.js
@@ -6,25 +6,19 @@ moduloActividad(nombre, () => {
 
 	actividadTest(nombre, {
 		solucion: `<xml xmlns="http://www.w3.org/1999/xhtml">
-		<variables>
-		  <variable type="math_number" id=".~:L;MZH3#_ch^(xj6@4">cantidad</variable>
-		</variables>
 		<block type="al_empezar_a_ejecutar" id="115" deletable="false" movable="false" editable="false" x="0" y="0">
 		  <statement name="program">
-			<shadow type="required_statement" id="oDul2_6$rV7|OIOxg0l"></shadow>
 			<block type="procedures_callnoreturn" id="308">
 			  <mutation name="Agarrar trofeos hacia">
 				<arg name="cantidad"></arg>
 				<arg name="direccion"></arg>
 			  </mutation>
 			  <value name="ARG0">
-				<shadow xmlns="" type="required_value"/>
 				<block type="math_number" id="320">
 				  <field name="NUM">4</field>
 				</block>
 			  </value>
 			  <value name="ARG1">
-				<shadow xmlns="" type="required_value"/>
 				<block type="ParaLaDerecha" id="314"></block>
 			  </value>
 			  <next>
@@ -34,13 +28,11 @@ moduloActividad(nombre, () => {
 					<arg name="direccion"></arg>
 				  </mutation>
 				  <value name="ARG0">
-					<shadow xmlns="" type="required_value"/>
 					<block type="math_number" id="192">
 					  <field name="NUM">3</field>
 					</block>
 				  </value>
 				  <value name="ARG1">
-					<shadow xmlns="" type="required_value"/>
 					<block type="ParaAbajo" id="275"></block>
 				  </value>
 				  <next>
@@ -50,13 +42,11 @@ moduloActividad(nombre, () => {
 						<arg name="direccion"></arg>
 					  </mutation>
 					  <value name="ARG0">
-						<shadow xmlns="" type="required_value"/>
 						<block type="math_number" id="198">
 						  <field name="NUM">4</field>
 						</block>
 					  </value>
 					  <value name="ARG1">
-						<shadow xmlns="" type="required_value"/>
 						<block type="ParaLaIzquierda" id="284"></block>
 					  </value>
 					  <next>
@@ -66,13 +56,11 @@ moduloActividad(nombre, () => {
 							<arg name="direccion"></arg>
 						  </mutation>
 						  <value name="ARG0">
-							<shadow xmlns="" type="required_value"/>
 							<block type="math_number" id="205">
 							  <field name="NUM">3</field>
 							</block>
 						  </value>
 						  <value name="ARG1">
-							<shadow xmlns="" type="required_value"/>
 							<block type="ParaArriba" id="290"></block>
 						  </value>
 						  <next>
@@ -112,7 +100,6 @@ moduloActividad(nombre, () => {
 					</block>
 				  </value>
 				  <statement name="block">
-					<shadow type="required_statement" id="##,3~5b4!+Se54x#ge.D"></shadow>
 					<block type="RecogerTrofeo" id="160">
 					  <next>
 						<block type="MoverA" id="157">
@@ -135,16 +122,13 @@ moduloActividad(nombre, () => {
 		  <statement name="STACK">
 			<block type="Repetir" id="234">
 			  <value name="count">
-				<shadow type="required_value" id="D4m!h{+@gO2c1BrzkTMp"></shadow>
 				<block type="math_number" id="235">
 				  <field name="NUM">2</field>
 				</block>
 			  </value>
 			  <statement name="block">
-				<shadow type="required_statement" id="%,0:y*ZK+a_07o*/D~1V"></shadow>
 				<block type="MoverA" id="210">
 				  <value name="direccion">
-					<shadow type="required_value" id="K[WegV(@8ZcHAa[08c4)"></shadow>
 					<block type="ParaAbajo" id="241"></block>
 				  </value>
 				</block>
@@ -156,13 +140,11 @@ moduloActividad(nombre, () => {
 					<arg name="direccion"></arg>
 				  </mutation>
 				  <value name="ARG0">
-					<shadow xmlns="" type="required_value"/>
 					<block type="math_number" id="269">
 					  <field name="NUM">4</field>
 					</block>
 				  </value>
 				  <value name="ARG1">
-					<shadow xmlns="" type="required_value"/>
 					<block type="ParaLaDerecha" id="263"></block>
 				  </value>
 				</block>

--- a/tests/integration/desafios/segundoCiclo/Chuy/InfinitosTrofeos-test.js
+++ b/tests/integration/desafios/segundoCiclo/Chuy/InfinitosTrofeos-test.js
@@ -7,16 +7,15 @@ moduloActividad(nombre, () => {
 	actividadTest(nombre, {
 		solucion: `<xml xmlns="http://www.w3.org/1999/xhtml">
 		<variables>
-		  <variable type="" id=".~:L;MZH3#_ch^(xj6@4">cantidad</variable>
-		  <variable type="" id="Fx]s3z{~2.?O{SlEh{#C">direccion</variable>
+		  <variable type="math_number" id=".~:L;MZH3#_ch^(xj6@4">cantidad</variable>
 		</variables>
 		<block type="al_empezar_a_ejecutar" id="115" deletable="false" movable="false" editable="false" x="0" y="0">
 		  <statement name="program">
-			<shadow type="required_statement" id="!y0Yy-v\`b%).EO}xnYu8"></shadow>
+			<shadow type="required_statement" id="oDul2_6$rV7|OIOxg0l"></shadow>
 			<block type="procedures_callnoreturn" id="308">
 			  <mutation name="Agarrar trofeos hacia">
-				<arg name="cantidad = 3"></arg>
-				<arg name="direccion = abajo"></arg>
+				<arg name="cantidad"></arg>
+				<arg name="direccion"></arg>
 			  </mutation>
 			  <value name="ARG0">
 				<shadow xmlns="" type="required_value"/>
@@ -31,8 +30,8 @@ moduloActividad(nombre, () => {
 			  <next>
 				<block type="procedures_callnoreturn" id="180">
 				  <mutation name="Agarrar trofeos hacia">
-					<arg name="cantidad = 3"></arg>
-					<arg name="direccion = abajo"></arg>
+					<arg name="cantidad"></arg>
+					<arg name="direccion"></arg>
 				  </mutation>
 				  <value name="ARG0">
 					<shadow xmlns="" type="required_value"/>
@@ -47,8 +46,8 @@ moduloActividad(nombre, () => {
 				  <next>
 					<block type="procedures_callnoreturn" id="186">
 					  <mutation name="Agarrar trofeos hacia">
-						<arg name="cantidad = 3"></arg>
-						<arg name="direccion = abajo"></arg>
+						<arg name="cantidad"></arg>
+						<arg name="direccion"></arg>
 					  </mutation>
 					  <value name="ARG0">
 						<shadow xmlns="" type="required_value"/>
@@ -63,8 +62,8 @@ moduloActividad(nombre, () => {
 					  <next>
 						<block type="procedures_callnoreturn" id="183">
 						  <mutation name="Agarrar trofeos hacia">
-							<arg name="cantidad = 3"></arg>
-							<arg name="direccion = abajo"></arg>
+							<arg name="cantidad"></arg>
+							<arg name="direccion"></arg>
 						  </mutation>
 						  <value name="ARG0">
 							<shadow xmlns="" type="required_value"/>
@@ -92,40 +91,37 @@ moduloActividad(nombre, () => {
 		</block>
 		<block type="procedures_defnoreturn" id="126" x="20" y="230">
 		  <mutation>
-			<arg name="cantidad = 3"></arg>
-			<arg name="direccion = abajo"></arg>
+			<arg name="cantidad"></arg>
+			<arg name="direccion"></arg>
 		  </mutation>
 		  <field name="NAME">Agarrar trofeos hacia</field>
-		  <field name="ARG0">cantidad = 3</field>
-		  <field name="ARG1">direccion = abajo</field>
+		  <field name="ARG0">cantidad</field>
+		  <field name="ARG1">direccion</field>
 		  <statement name="STACK">
 			<block type="MoverA" id="323">
-			  <value name="direccion">
-				<shadow type="required_value" id="(svjwFjIpWXA:TnbdyX:"></shadow>
-				<block type="variables_get" id="FS2I:r5V\`K4o/}RQ?|om">
-				  <mutation var="direccion = abajo" parent="126"></mutation>
-				</block>
-			  </value>
+				<value name="direccion">
+					<block type="param_get" id="261a">
+					<field name="VAR">direccion</field>
+					</block>
+				</value>
 			  <next>
 				<block type="Repetir" id="141">
 				  <value name="count">
-					<shadow type="required_value" id=".=tR[b{gHy[dieFq@|4R"></shadow>
-					<block type="variables_get" id="@26j1B#)[_pjToaNW2Qj">
-					  <mutation var="cantidad = 3" parent="126"></mutation>
+					<block type="param_get" id="26">
+						<field name="VAR">cantidad</field>
 					</block>
 				  </value>
 				  <statement name="block">
-					<shadow type="required_statement" id="a4,G/S0$-QXOb/.6M$l?"></shadow>
+					<shadow type="required_statement" id="##,3~5b4!+Se54x#ge.D"></shadow>
 					<block type="RecogerTrofeo" id="160">
 					  <next>
 						<block type="MoverA" id="157">
-						  <value name="direccion">
-							<shadow type="required_value" id="tLW5RE(}3qJd%r4yU)/X"></shadow>
-							<block type="variables_get" id="A$I=sXn2/C/-w-dC{cM$">
-							  <mutation var="direccion = abajo" parent="126"></mutation>
-							</block>
-						  </value>
-						</block>
+							<value name="direccion">
+								<block type="param_get" id="261b">
+								<field name="VAR">direccion</field>
+								</block>
+							</value>
+					   </block>
 					  </next>
 					</block>
 				  </statement>
@@ -139,16 +135,16 @@ moduloActividad(nombre, () => {
 		  <statement name="STACK">
 			<block type="Repetir" id="234">
 			  <value name="count">
-				<shadow type="required_value" id="3X2Cpvbi#Hn5^7|zMava"></shadow>
+				<shadow type="required_value" id="D4m!h{+@gO2c1BrzkTMp"></shadow>
 				<block type="math_number" id="235">
 				  <field name="NUM">2</field>
 				</block>
 			  </value>
 			  <statement name="block">
-				<shadow type="required_statement" id="5E3p3kj!QPD[LEQHJGO*"></shadow>
+				<shadow type="required_statement" id="%,0:y*ZK+a_07o*/D~1V"></shadow>
 				<block type="MoverA" id="210">
 				  <value name="direccion">
-					<shadow type="required_value" id="#GOy+C3;J^$OPq3E@tU/"></shadow>
+					<shadow type="required_value" id="K[WegV(@8ZcHAa[08c4)"></shadow>
 					<block type="ParaAbajo" id="241"></block>
 				  </value>
 				</block>
@@ -156,8 +152,8 @@ moduloActividad(nombre, () => {
 			  <next>
 				<block type="procedures_callnoreturn" id="257">
 				  <mutation name="Agarrar trofeos hacia">
-					<arg name="cantidad = 3"></arg>
-					<arg name="direccion = abajo"></arg>
+					<arg name="cantidad"></arg>
+					<arg name="direccion"></arg>
 				  </mutation>
 				  <value name="ARG0">
 					<shadow xmlns="" type="required_value"/>
@@ -174,8 +170,7 @@ moduloActividad(nombre, () => {
 			</block>
 		  </statement>
 		</block>
-	  </xml>`,
-	  skip: true
+	  </xml>`
 	});
 
 });

--- a/tests/integration/desafios/segundoCiclo/Chuy/InfinitosTrofeos-test.js
+++ b/tests/integration/desafios/segundoCiclo/Chuy/InfinitosTrofeos-test.js
@@ -6,153 +6,153 @@ moduloActividad(nombre, () => {
 
 	actividadTest(nombre, {
 		solucion: `<xml xmlns="http://www.w3.org/1999/xhtml">
-		<block type="al_empezar_a_ejecutar" id="115" deletable="false" movable="false" editable="false" x="0" y="0">
-		  <statement name="program">
-			<block type="procedures_callnoreturn" id="308">
-			  <mutation name="Agarrar trofeos hacia">
-				<arg name="cantidad"></arg>
-				<arg name="direccion"></arg>
-			  </mutation>
-			  <value name="ARG0">
-				<block type="math_number" id="320">
-				  <field name="NUM">4</field>
-				</block>
-			  </value>
-			  <value name="ARG1">
-				<block type="ParaLaDerecha" id="314"></block>
-			  </value>
-			  <next>
-				<block type="procedures_callnoreturn" id="180">
-				  <mutation name="Agarrar trofeos hacia">
-					<arg name="cantidad"></arg>
-					<arg name="direccion"></arg>
-				  </mutation>
-				  <value name="ARG0">
-					<block type="math_number" id="192">
-					  <field name="NUM">3</field>
-					</block>
-				  </value>
-				  <value name="ARG1">
-					<block type="ParaAbajo" id="275"></block>
-				  </value>
-				  <next>
-					<block type="procedures_callnoreturn" id="186">
-					  <mutation name="Agarrar trofeos hacia">
-						<arg name="cantidad"></arg>
-						<arg name="direccion"></arg>
-					  </mutation>
-					  <value name="ARG0">
-						<block type="math_number" id="198">
-						  <field name="NUM">4</field>
-						</block>
-					  </value>
-					  <value name="ARG1">
-						<block type="ParaLaIzquierda" id="284"></block>
-					  </value>
-					  <next>
-						<block type="procedures_callnoreturn" id="183">
-						  <mutation name="Agarrar trofeos hacia">
+			<block type="al_empezar_a_ejecutar" id="115" deletable="false" movable="false" editable="false" x="0" y="0">
+				<statement name="program">
+					<block type="procedures_callnoreturn" id="308" inline="true">
+						<mutation name="Agarrar trofeos hacia">
 							<arg name="cantidad"></arg>
 							<arg name="direccion"></arg>
-						  </mutation>
-						  <value name="ARG0">
-							<block type="math_number" id="205">
-							  <field name="NUM">3</field>
+						</mutation>
+						<value name="ARG0">
+							<block type="math_number" id="320">
+								<field name="NUM">4</field>
 							</block>
-						  </value>
-						  <value name="ARG1">
-							<block type="ParaArriba" id="290"></block>
-						  </value>
-						  <next>
-							<block type="procedures_callnoreturn" id="299">
-							  <mutation name="Agarrar trofeos centro"></mutation>
-							</block>
-						  </next>
-						</block>
-					  </next>
-					</block>
-				  </next>
-				</block>
-			  </next>
-			</block>
-		  </statement>
-		</block>
-		<block type="procedures_defnoreturn" id="126" x="20" y="230">
-		  <mutation>
-			<arg name="cantidad"></arg>
-			<arg name="direccion"></arg>
-		  </mutation>
-		  <field name="NAME">Agarrar trofeos hacia</field>
-		  <field name="ARG0">cantidad</field>
-		  <field name="ARG1">direccion</field>
-		  <statement name="STACK">
-			<block type="MoverA" id="323">
-				<value name="direccion">
-					<block type="param_get" id="261a">
-					<field name="VAR">direccion</field>
-					</block>
-				</value>
-			  <next>
-				<block type="Repetir" id="141">
-				  <value name="count">
-					<block type="param_get" id="26">
-						<field name="VAR">cantidad</field>
-					</block>
-				  </value>
-				  <statement name="block">
-					<block type="RecogerTrofeo" id="160">
-					  <next>
-						<block type="MoverA" id="157">
-							<value name="direccion">
-								<block type="param_get" id="261b">
-								<field name="VAR">direccion</field>
+						</value>
+						<value name="ARG1">
+							<block type="ParaLaDerecha" id="314"></block>
+						</value>
+						<next>
+							<block type="procedures_callnoreturn" id="180" inline="true">
+								<mutation name="Agarrar trofeos hacia">
+									<arg name="cantidad"></arg>
+									<arg name="direccion"></arg>
+								</mutation>
+								<value name="ARG0">
+									<block type="math_number" id="192">
+										<field name="NUM">3</field>
+									</block>
+								</value>
+								<value name="ARG1">
+									<block type="ParaAbajo" id="275"></block>
+								</value>
+								<next>
+								<block type="procedures_callnoreturn" id="186" inline="true">
+								<mutation name="Agarrar trofeos hacia">
+									<arg name="cantidad"></arg>
+									<arg name="direccion"></arg>
+								</mutation>
+								<value name="ARG0">
+									<block type="math_number" id="198">
+										<field name="NUM">4</field>
+									</block>
+								</value>
+								<value name="ARG1">
+									<block type="ParaLaIzquierda" id="284"></block>
+								</value>
+								<next>
+								<block type="procedures_callnoreturn" id="183" inline="true">
+								<mutation name="Agarrar trofeos hacia">
+									<arg name="cantidad"></arg>
+									<arg name="direccion"></arg>
+								</mutation>
+								<value name="ARG0">
+									<block type="math_number" id="205">
+										<field name="NUM">3</field>
+									</block>
+								</value>
+								<value name="ARG1">
+									<block type="ParaArriba" id="290"></block>
+								</value>
+								<next>
+								<block type="procedures_callnoreturn" id="299">
+									<mutation name="Agarrar trofeos centro">
+									</mutation>
 								</block>
-							</value>
-					   </block>
-					  </next>
+								</next>
+							</block>
+							</next>
+						</block>
+						</next>
 					</block>
-				  </statement>
-				</block>
-			  </next>
+					</next>
+					</block>
+				</statement>
 			</block>
-		  </statement>
-		</block>
-		<block type="procedures_defnoreturn" id="221" x="414" y="240">
-		  <field name="NAME">Agarrar trofeos centro</field>
-		  <statement name="STACK">
-			<block type="Repetir" id="234">
-			  <value name="count">
-				<block type="math_number" id="235">
-				  <field name="NUM">2</field>
-				</block>
-			  </value>
-			  <statement name="block">
-				<block type="MoverA" id="210">
-				  <value name="direccion">
-					<block type="ParaAbajo" id="241"></block>
-				  </value>
-				</block>
-			  </statement>
-			  <next>
-				<block type="procedures_callnoreturn" id="257">
-				  <mutation name="Agarrar trofeos hacia">
+			<block type="procedures_defnoreturn" id="126" x="20" y="230">
+				<mutation>
 					<arg name="cantidad"></arg>
 					<arg name="direccion"></arg>
-				  </mutation>
-				  <value name="ARG0">
-					<block type="math_number" id="269">
-					  <field name="NUM">4</field>
+				</mutation>
+				<field name="NAME">Agarrar trofeos hacia</field>
+				<statement name="STACK">
+					<block type="MoverA" id="323" inline="true">
+						<value name="direccion">
+							<block type="param_get" id="328">
+								<field name="VAR">direccion</field>
+							</block>
+						</value>
+						<next>
+						<block type="Repetir" id="141" inline="true">
+							<value name="count">
+								<block type="param_get" id="147">
+									<field name="VAR">cantidad</field>
+								</block>
+							</value>
+							<statement name="block">
+								<block type="RecogerTrofeo" id="160">
+									<next>
+									<block type="MoverA" id="157" inline="true">
+										<value name="direccion">
+											<block type="param_get" id="152">
+												<field name="VAR">direccion</field>
+											</block>
+										</value>
+									</block>
+									</next>
+								</block>
+							</statement>
+						</block>
+						</next>
 					</block>
-				  </value>
-				  <value name="ARG1">
-					<block type="ParaLaDerecha" id="263"></block>
-				  </value>
-				</block>
-			  </next>
+				</statement>
 			</block>
-		  </statement>
-		</block>
-	  </xml>`
+			<block type="procedures_defnoreturn" id="221" x="40" y="399">
+				<mutation></mutation>
+				<field name="NAME">Agarrar trofeos centro</field>
+				<statement name="STACK">
+					<block type="Repetir" id="234" inline="true">
+						<value name="count">
+							<block type="math_number" id="235">
+								<field name="NUM">2</field>
+							</block>
+						</value>
+						<statement name="block">
+							<block type="MoverA" id="210" inline="true">
+								<value name="direccion">
+									<block type="ParaAbajo" id="241"></block>
+								</value>
+							</block>
+						</statement>
+						<next>
+						<block type="procedures_callnoreturn" id="257" inline="true">
+							<mutation name="Agarrar trofeos hacia">
+								<arg name="cantidad"></arg>
+								<arg name="direccion"></arg>
+							</mutation>
+							<value name="ARG0">
+								<block type="math_number" id="269">
+									<field name="NUM">4</field>
+								</block>
+							</value>
+							<value name="ARG1">
+								<block type="ParaLaDerecha" id="263"></block>
+							</value>
+						</block>
+						</next>
+					</block>
+				</statement>
+			</block>
+		</xml>`
 	});
 
 });

--- a/tests/integration/desafios/segundoCiclo/Chuy/InfinitosTrofeos-test.js
+++ b/tests/integration/desafios/segundoCiclo/Chuy/InfinitosTrofeos-test.js
@@ -6,65 +6,65 @@ moduloActividad(nombre, () => {
 
 	actividadTest(nombre, {
 		solucion: `<xml xmlns="http://www.w3.org/1999/xhtml">
-			<block type="al_empezar_a_ejecutar" id="115" deletable="false" movable="false" editable="false" x="0" y="0">
+			<block type="al_empezar_a_ejecutar" deletable="false" movable="false" editable="false" x="0" y="0">
 				<statement name="program">
-					<block type="procedures_callnoreturn" id="308" inline="true">
+					<block type="procedures_callnoreturn" inline="true">
 						<mutation name="Agarrar trofeos hacia">
 							<arg name="cantidad"></arg>
 							<arg name="direccion"></arg>
 						</mutation>
 						<value name="ARG0">
-							<block type="math_number" id="320">
+							<block type="math_number">
 								<field name="NUM">4</field>
 							</block>
 						</value>
 						<value name="ARG1">
-							<block type="ParaLaDerecha" id="314"></block>
+							<block type="ParaLaDerecha"></block>
 						</value>
 						<next>
-							<block type="procedures_callnoreturn" id="180" inline="true">
+							<block type="procedures_callnoreturn" inline="true">
 								<mutation name="Agarrar trofeos hacia">
 									<arg name="cantidad"></arg>
 									<arg name="direccion"></arg>
 								</mutation>
 								<value name="ARG0">
-									<block type="math_number" id="192">
+									<block type="math_number">
 										<field name="NUM">3</field>
 									</block>
 								</value>
 								<value name="ARG1">
-									<block type="ParaAbajo" id="275"></block>
+									<block type="ParaAbajo"></block>
 								</value>
 								<next>
-								<block type="procedures_callnoreturn" id="186" inline="true">
+								<block type="procedures_callnoreturn" inline="true">
 								<mutation name="Agarrar trofeos hacia">
 									<arg name="cantidad"></arg>
 									<arg name="direccion"></arg>
 								</mutation>
 								<value name="ARG0">
-									<block type="math_number" id="198">
+									<block type="math_number">
 										<field name="NUM">4</field>
 									</block>
 								</value>
 								<value name="ARG1">
-									<block type="ParaLaIzquierda" id="284"></block>
+									<block type="ParaLaIzquierda"></block>
 								</value>
 								<next>
-								<block type="procedures_callnoreturn" id="183" inline="true">
+								<block type="procedures_callnoreturn" inline="true">
 								<mutation name="Agarrar trofeos hacia">
 									<arg name="cantidad"></arg>
 									<arg name="direccion"></arg>
 								</mutation>
 								<value name="ARG0">
-									<block type="math_number" id="205">
+									<block type="math_number">
 										<field name="NUM">3</field>
 									</block>
 								</value>
 								<value name="ARG1">
-									<block type="ParaArriba" id="290"></block>
+									<block type="ParaArriba"></block>
 								</value>
 								<next>
-								<block type="procedures_callnoreturn" id="299">
+								<block type="procedures_callnoreturn">
 									<mutation name="Agarrar trofeos centro">
 									</mutation>
 								</block>
@@ -78,32 +78,32 @@ moduloActividad(nombre, () => {
 					</block>
 				</statement>
 			</block>
-			<block type="procedures_defnoreturn" id="126" x="20" y="230">
+			<block type="procedures_defnoreturn" x="20" y="230">
 				<mutation>
 					<arg name="cantidad"></arg>
 					<arg name="direccion"></arg>
 				</mutation>
 				<field name="NAME">Agarrar trofeos hacia</field>
 				<statement name="STACK">
-					<block type="MoverA" id="323" inline="true">
+					<block type="MoverA" inline="true">
 						<value name="direccion">
-							<block type="param_get" id="328">
+							<block type="param_get">
 								<field name="VAR">direccion</field>
 							</block>
 						</value>
 						<next>
-						<block type="Repetir" id="141" inline="true">
+						<block type="Repetir" inline="true">
 							<value name="count">
-								<block type="param_get" id="147">
+								<block type="param_get">
 									<field name="VAR">cantidad</field>
 								</block>
 							</value>
 							<statement name="block">
-								<block type="RecogerTrofeo" id="160">
+								<block type="RecogerTrofeo">
 									<next>
-									<block type="MoverA" id="157" inline="true">
+									<block type="MoverA" inline="true">
 										<value name="direccion">
-											<block type="param_get" id="152">
+											<block type="param_get">
 												<field name="VAR">direccion</field>
 											</block>
 										</value>
@@ -116,36 +116,36 @@ moduloActividad(nombre, () => {
 					</block>
 				</statement>
 			</block>
-			<block type="procedures_defnoreturn" id="221" x="40" y="399">
+			<block type="procedures_defnoreturn" x="40" y="399">
 				<mutation></mutation>
 				<field name="NAME">Agarrar trofeos centro</field>
 				<statement name="STACK">
-					<block type="Repetir" id="234" inline="true">
+					<block type="Repetir" inline="true">
 						<value name="count">
-							<block type="math_number" id="235">
+							<block type="math_number">
 								<field name="NUM">2</field>
 							</block>
 						</value>
 						<statement name="block">
-							<block type="MoverA" id="210" inline="true">
+							<block type="MoverA" inline="true">
 								<value name="direccion">
-									<block type="ParaAbajo" id="241"></block>
+									<block type="ParaAbajo"></block>
 								</value>
 							</block>
 						</statement>
 						<next>
-						<block type="procedures_callnoreturn" id="257" inline="true">
+						<block type="procedures_callnoreturn" inline="true">
 							<mutation name="Agarrar trofeos hacia">
 								<arg name="cantidad"></arg>
 								<arg name="direccion"></arg>
 							</mutation>
 							<value name="ARG0">
-								<block type="math_number" id="269">
+								<block type="math_number">
 									<field name="NUM">4</field>
 								</block>
 							</value>
 							<value name="ARG1">
-								<block type="ParaLaDerecha" id="263"></block>
+								<block type="ParaLaDerecha"></block>
 							</value>
 						</block>
 						</next>

--- a/tests/integration/desafios/segundoCiclo/Yvoty/MariposasEncuadradas-test.js
+++ b/tests/integration/desafios/segundoCiclo/Yvoty/MariposasEncuadradas-test.js
@@ -7,7 +7,7 @@ moduloActividad(nombre, () => {
    actividadTest(nombre, {
       solucion: `<xml xmlns="http://www.w3.org/1999/xhtml">
       <variables>
-        <variable type="" id=";Hpnm3IaG$0W5,m[@zX/">direccion</variable>
+        <variable type="math_number" id=";Hpnm3IaG$0W5,m[@zX/">direccion</variable>
       </variables>
       <block type="al_empezar_a_ejecutar" id="13" deletable="false" movable="false" editable="false" x="0" y="0">
         <statement name="program">
@@ -73,12 +73,11 @@ moduloActividad(nombre, () => {
             <statement name="block">
               <shadow type="required_statement" id="o2C:cvl~r3@y,AQr;B+]"></shadow>
               <block type="MoverA" id="25">
-                <value name="direccion">
-                  <shadow type="required_value" id="4$-aX;}BR1@|Y\`B@]FP0"></shadow>
-                  <block type="variables_get" id="ox1nJ+c8Hl1(LpwS]_TK">
-                    <mutation var="direccion" parent="22"></mutation>
-                  </block>
-                </value>
+                  <value name="direccion">
+                    <block type="param_get" id="26">
+                      <field name="VAR">direccion</field>
+                    </block>
+                  </value>
                 <next>
                   <block type="procedures_callnoreturn" id="27">
                     <mutation name="Observar mariposa si hay"></mutation>
@@ -104,8 +103,7 @@ moduloActividad(nombre, () => {
           </block>
         </statement>
       </block>
-    </xml>`,
-    skip: true
+    </xml>`
    });
 
 });

--- a/tests/integration/desafios/segundoCiclo/Yvoty/MariposasEncuadradas-test.js
+++ b/tests/integration/desafios/segundoCiclo/Yvoty/MariposasEncuadradas-test.js
@@ -7,38 +7,38 @@ moduloActividad(nombre, () => {
    actividadTest(nombre, {
       solucion: `<?xml version="1.0" encoding="UTF-8"?>
         <xml xmlns="http://www.w3.org/1999/xhtml">
-         <block type="al_empezar_a_ejecutar" id="12" deletable="false" movable="false" editable="false" x="0" y="0">
+         <block type="al_empezar_a_ejecutar" deletable="false" movable="false" editable="false" x="0" y="0">
             <statement name="program">
-               <block type="procedures_callnoreturn" id="14" inline="true">
+               <block type="procedures_callnoreturn" inline="true">
                   <mutation name="Observar mariposas hacia">
                      <arg name="direccion" />
                   </mutation>
                   <value name="ARG0">
-                     <block type="ParaLaDerecha" id="15" />
+                     <block type="ParaLaDerecha"/>
                   </value>
                   <next>
-                     <block type="procedures_callnoreturn" id="20" inline="true">
+                     <block type="procedures_callnoreturn" inline="true">
                         <mutation name="Observar mariposas hacia">
                            <arg name="direccion" />
                         </mutation>
                         <value name="ARG0">
-                           <block type="ParaAbajo" id="21" />
+                           <block type="ParaAbajo"/>
                         </value>
                         <next>
-                           <block type="procedures_callnoreturn" id="16" inline="true">
+                           <block type="procedures_callnoreturn" inline="true">
                               <mutation name="Observar mariposas hacia">
                                  <arg name="direccion" />
                               </mutation>
                               <value name="ARG0">
-                                 <block type="ParaLaIzquierda" id="17" />
+                                 <block type="ParaLaIzquierda"/>
                               </value>
                               <next>
-                                 <block type="procedures_callnoreturn" id="18" inline="true">
+                                 <block type="procedures_callnoreturn" inline="true">
                                     <mutation name="Observar mariposas hacia">
                                        <arg name="direccion" />
                                     </mutation>
                                     <value name="ARG0">
-                                       <block type="ParaArriba" id="19" />
+                                       <block type="ParaArriba"/>
                                     </value>
                                  </block>
                               </next>
@@ -49,27 +49,27 @@ moduloActividad(nombre, () => {
                </block>
             </statement>
          </block>
-         <block type="procedures_defnoreturn" id="22" x="0" y="196">
+         <block type="procedures_defnoreturn" x="0" y="196">
             <mutation>
                <arg name="direccion" />
             </mutation>
             <field name="NAME">Observar mariposas hacia</field>
             <statement name="STACK">
-               <block type="Repetir" id="23" inline="true">
+               <block type="Repetir" inline="true">
                   <value name="count">
-                     <block type="math_number" id="24">
+                     <block type="math_number">
                         <field name="NUM">6</field>
                      </block>
                   </value>
                   <statement name="block">
-                     <block type="MoverA" id="25" inline="true">
+                     <block type="MoverA" inline="true">
                         <value name="direccion">
-                           <block type="param_get" id="26">
+                           <block type="param_get">
                               <field name="VAR">direccion</field>
                            </block>
                         </value>
                         <next>
-                           <block type="procedures_callnoreturn" id="27">
+                           <block type="procedures_callnoreturn">
                               <mutation name="Prender luz si hay" />
                            </block>
                         </next>
@@ -78,16 +78,16 @@ moduloActividad(nombre, () => {
                </block>
             </statement>
          </block>
-         <block type="procedures_defnoreturn" id="28" x="2" y="363">
+         <block type="procedures_defnoreturn" x="2" y="363">
             <mutation />
             <field name="NAME">Prender luz si hay</field>
             <statement name="STACK">
-               <block type="si" id="29" inline="true">
+               <block type="si" inline="true">
                   <value name="condition">
-                    <block type="TocandoMariposa" id="30"></block>
+                    <block type="TocandoMariposa"></block>
                   </value>
                   <statement name="block">
-                    <block type="FotografiarMariposa" id="31"></block>
+                    <block type="FotografiarMariposa"></block>
                   </statement>
                </block>
             </statement>

--- a/tests/integration/desafios/segundoCiclo/Yvoty/MariposasEncuadradas-test.js
+++ b/tests/integration/desafios/segundoCiclo/Yvoty/MariposasEncuadradas-test.js
@@ -6,18 +6,13 @@ moduloActividad(nombre, () => {
 
    actividadTest(nombre, {
       solucion: `<xml xmlns="http://www.w3.org/1999/xhtml">
-      <variables>
-        <variable type="math_number" id=";Hpnm3IaG$0W5,m[@zX/">direccion</variable>
-      </variables>
       <block type="al_empezar_a_ejecutar" id="13" deletable="false" movable="false" editable="false" x="0" y="0">
         <statement name="program">
-          <shadow type="required_statement" id="zfb.S.6LX24[.%Yiu9tr"></shadow>
           <block type="procedures_callnoreturn" id="14">
             <mutation name="Observar mariposas hacia">
               <arg name="direccion"></arg>
             </mutation>
             <value name="ARG0">
-              <shadow xmlns="" type="required_value"/>
               <block type="ParaLaDerecha" id="15"></block>
             </value>
             <next>
@@ -26,7 +21,6 @@ moduloActividad(nombre, () => {
                   <arg name="direccion"></arg>
                 </mutation>
                 <value name="ARG0">
-                  <shadow xmlns="" type="required_value"/>
                   <block type="ParaAbajo" id="21"></block>
                 </value>
                 <next>
@@ -35,7 +29,6 @@ moduloActividad(nombre, () => {
                       <arg name="direccion"></arg>
                     </mutation>
                     <value name="ARG0">
-                      <shadow xmlns="" type="required_value"/>
                       <block type="ParaLaIzquierda" id="17"></block>
                     </value>
                     <next>
@@ -44,7 +37,6 @@ moduloActividad(nombre, () => {
                           <arg name="direccion"></arg>
                         </mutation>
                         <value name="ARG0">
-                          <shadow xmlns="" type="required_value"/>
                           <block type="ParaArriba" id="19"></block>
                         </value>
                       </block>
@@ -65,13 +57,11 @@ moduloActividad(nombre, () => {
         <statement name="STACK">
           <block type="Repetir" id="23">
             <value name="count">
-              <shadow type="required_value" id="7ek+vVl[m*#]:{i=}(0V"></shadow>
               <block type="math_number" id="24">
                 <field name="NUM">6</field>
               </block>
             </value>
             <statement name="block">
-              <shadow type="required_statement" id="o2C:cvl~r3@y,AQr;B+]"></shadow>
               <block type="MoverA" id="25">
                   <value name="direccion">
                     <block type="param_get" id="26">
@@ -93,11 +83,9 @@ moduloActividad(nombre, () => {
         <statement name="STACK">
           <block type="si" id="29">
             <value name="condition">
-              <shadow type="required_value" id="Z+Wpu$Dn+B@rqL;I\`[NY"></shadow>
               <block type="TocandoMariposa" id="30"></block>
             </value>
             <statement name="block">
-              <shadow type="required_statement" id="^Dx\`KpAK\`MbXQ(@eatkT"></shadow>
               <block type="FotografiarMariposa" id="31"></block>
             </statement>
           </block>

--- a/tests/integration/desafios/segundoCiclo/Yvoty/MariposasEncuadradas-test.js
+++ b/tests/integration/desafios/segundoCiclo/Yvoty/MariposasEncuadradas-test.js
@@ -5,93 +5,93 @@ let nombre = "MariposasEncuadradas";
 moduloActividad(nombre, () => {
 
    actividadTest(nombre, {
-      solucion: `<xml xmlns="http://www.w3.org/1999/xhtml">
-      <block type="al_empezar_a_ejecutar" id="13" deletable="false" movable="false" editable="false" x="0" y="0">
-        <statement name="program">
-          <block type="procedures_callnoreturn" id="14">
-            <mutation name="Observar mariposas hacia">
-              <arg name="direccion"></arg>
-            </mutation>
-            <value name="ARG0">
-              <block type="ParaLaDerecha" id="15"></block>
-            </value>
-            <next>
-              <block type="procedures_callnoreturn" id="20">
-                <mutation name="Observar mariposas hacia">
-                  <arg name="direccion"></arg>
-                </mutation>
-                <value name="ARG0">
-                  <block type="ParaAbajo" id="21"></block>
-                </value>
-                <next>
-                  <block type="procedures_callnoreturn" id="16">
-                    <mutation name="Observar mariposas hacia">
-                      <arg name="direccion"></arg>
-                    </mutation>
-                    <value name="ARG0">
-                      <block type="ParaLaIzquierda" id="17"></block>
-                    </value>
-                    <next>
-                      <block type="procedures_callnoreturn" id="18">
+      solucion: `<?xml version="1.0" encoding="UTF-8"?>
+        <xml xmlns="http://www.w3.org/1999/xhtml">
+         <block type="al_empezar_a_ejecutar" id="12" deletable="false" movable="false" editable="false" x="0" y="0">
+            <statement name="program">
+               <block type="procedures_callnoreturn" id="14" inline="true">
+                  <mutation name="Observar mariposas hacia">
+                     <arg name="direccion" />
+                  </mutation>
+                  <value name="ARG0">
+                     <block type="ParaLaDerecha" id="15" />
+                  </value>
+                  <next>
+                     <block type="procedures_callnoreturn" id="20" inline="true">
                         <mutation name="Observar mariposas hacia">
-                          <arg name="direccion"></arg>
+                           <arg name="direccion" />
                         </mutation>
                         <value name="ARG0">
-                          <block type="ParaArriba" id="19"></block>
+                           <block type="ParaAbajo" id="21" />
                         </value>
-                      </block>
-                    </next>
-                  </block>
-                </next>
-              </block>
-            </next>
-          </block>
-        </statement>
-      </block>
-      <block type="procedures_defnoreturn" id="22" x="0" y="196">
-        <mutation>
-          <arg name="direccion"></arg>
-        </mutation>
-        <field name="NAME">Observar mariposas hacia</field>
-        <field name="ARG0">direccion</field>
-        <statement name="STACK">
-          <block type="Repetir" id="23">
-            <value name="count">
-              <block type="math_number" id="24">
-                <field name="NUM">6</field>
-              </block>
-            </value>
-            <statement name="block">
-              <block type="MoverA" id="25">
-                  <value name="direccion">
-                    <block type="param_get" id="26">
-                      <field name="VAR">direccion</field>
-                    </block>
+                        <next>
+                           <block type="procedures_callnoreturn" id="16" inline="true">
+                              <mutation name="Observar mariposas hacia">
+                                 <arg name="direccion" />
+                              </mutation>
+                              <value name="ARG0">
+                                 <block type="ParaLaIzquierda" id="17" />
+                              </value>
+                              <next>
+                                 <block type="procedures_callnoreturn" id="18" inline="true">
+                                    <mutation name="Observar mariposas hacia">
+                                       <arg name="direccion" />
+                                    </mutation>
+                                    <value name="ARG0">
+                                       <block type="ParaArriba" id="19" />
+                                    </value>
+                                 </block>
+                              </next>
+                           </block>
+                        </next>
+                     </block>
+                  </next>
+               </block>
+            </statement>
+         </block>
+         <block type="procedures_defnoreturn" id="22" x="0" y="196">
+            <mutation>
+               <arg name="direccion" />
+            </mutation>
+            <field name="NAME">Observar mariposas hacia</field>
+            <statement name="STACK">
+               <block type="Repetir" id="23" inline="true">
+                  <value name="count">
+                     <block type="math_number" id="24">
+                        <field name="NUM">6</field>
+                     </block>
                   </value>
-                <next>
-                  <block type="procedures_callnoreturn" id="27">
-                    <mutation name="Observar mariposa si hay"></mutation>
-                  </block>
-                </next>
-              </block>
+                  <statement name="block">
+                     <block type="MoverA" id="25" inline="true">
+                        <value name="direccion">
+                           <block type="param_get" id="26">
+                              <field name="VAR">direccion</field>
+                           </block>
+                        </value>
+                        <next>
+                           <block type="procedures_callnoreturn" id="27">
+                              <mutation name="Prender luz si hay" />
+                           </block>
+                        </next>
+                     </block>
+                  </statement>
+               </block>
             </statement>
-          </block>
-        </statement>
-      </block>
-      <block type="procedures_defnoreturn" id="28" x="2" y="363">
-        <field name="NAME">Observar mariposa si hay</field>
-        <statement name="STACK">
-          <block type="si" id="29">
-            <value name="condition">
-              <block type="TocandoMariposa" id="30"></block>
-            </value>
-            <statement name="block">
-              <block type="FotografiarMariposa" id="31"></block>
+         </block>
+         <block type="procedures_defnoreturn" id="28" x="2" y="363">
+            <mutation />
+            <field name="NAME">Prender luz si hay</field>
+            <statement name="STACK">
+               <block type="si" id="29" inline="true">
+                  <value name="condition">
+                    <block type="TocandoMariposa" id="30"></block>
+                  </value>
+                  <statement name="block">
+                    <block type="FotografiarMariposa" id="31"></block>
+                  </statement>
+               </block>
             </statement>
-          </block>
-        </statement>
-      </block>
-    </xml>`
+         </block>
+      </xml>`
    });
-
 });


### PR DESCRIPTION
Resolves #1351 

Por alguna razon (que no pude descubrir a pesar de poder revisar el codigo) estos test que reciben parametros funcionan cuando el valor que se pasa, se pasa asi:

               <value name="direccion">
                    <block type="param_get" id="26">
                        <field name="VAR">direccion</field>
                    </block>
               </value>

y no asi:

                <value name="direccion">
                      <block type="variables_get" id="A$I=sXn2/C/-w-dC{cM$">
                           <mutation var="direccion" parent="126"></mutation>
                      </block>
                 </value>

Como que la interpretacion de mutation no estaria funcionando de la misma forma que lo hace cuando se utiliza field name.
luego, si el bloque es de tipo variables_get o param_get da igual. 

Cambiando esto en las soluciones, resolvió los tests

Parecia que el test se freezaba pero en realidad no se podia ejecutar (y por ello el timeout) por falta de bloques.
Cuando se ejecutan los tests si se destilda la opcion que oculta el contenedor del test (hide container), se pueden observar los bloques en pantalla y no solo la escena y alli se podia observar que faltaban bloques, aunque en realidad estaban, pero bajo la "definicion" de  `<mutation var>`

![image](https://github.com/Program-AR/pilas-bloques/assets/91342656/9f36f46a-f0c3-44c4-8911-6e3da13cc090)

y por otro lado, el error de los 2 test en el test:CI esta dado por el highlighter de procedimientos al analizar el campo id (que no tiene que ver con el id que le colocamos o no en la solucion). Supongo (sin mucho mas análisis realmente) que es a raiz de intentar **_highlightear_** (valga la expresion) la definicion del procedimiento y no el momento de la ejecucion. Pero no explica por qué no falla en TitoRecargado o en el CangrejoAguafiestas SALVO por el hecho de que estos desafios tienen una escena propia definida en exercises y los dos nuevos se construyen a partir de la escena generica de cada personaje (EscenaCapy/EscenaYvoty) 
La alternativa o contraprueba para verificar esto (que no hice aun) sería hacer para al menos uno de estos nuevos desafios, una clase en exercises como TitoRecargado, digamos un **InifinitosTrofeos** especifico y ver si a partir de alli, el test (volviendo el highlighter a como estaba) no falla. Porque es el unico argumento que puedo esgrimir para explicar la diferencia y por qué falla en uno y en otro no siendo que ambos tienen la misma solucion (porque salvo un par de bloques, las soluciones son identicas).